### PR TITLE
fix edit link url

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -41,7 +41,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/operaton/',
+            'https://github.com/operaton/documentation/blob/main/',
         },
         theme: {
           customCss: './src/css/custom.css',


### PR DESCRIPTION
fix edit link url, closes #21


when somebody wants contribute for the documentation it is possible do directly in github, however edit link is broken. Here are steps to reproduce:

open any documentation page: e.g. https://docs.operaton.org/docs/documentation/
click "edit this page" link
expected result: page is being opened in github
actual result: page not found is opened
The error can be fixed in docusaurus.config.ts updating editUrl parameter.