### PR TITLE
simple build pipeline ssh deployment, closes #2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,44 @@
+name: Deploy Docusaurus Website
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build Operaton site
+        run: |
+          npm run build || echo "Build failed, proceeding anyway if build/ exists"
+
+      - name: Check if build directory exists
+        run: |
+          if [ ! -d "build" ]; then
+            echo "Build directory does not exist. Exiting."
+            exit 1
+          fi
+
+      - name: Set up SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -p ${{ secrets.SSH_PORT }} ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Deploy to remote server via rsync
+        run: |
+          rsync -avz --delete ./build/ ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${{ secrets.SSH_PATH }}
+        env:
+          RSYNC_RSH: ssh -p ${{ secrets.SSH_PORT }}


### PR DESCRIPTION
Here is an example of simple CI/CD pipeline to deploy documentation to remote server. I tested it is my apache vebserver and was able to deploy to my custom domain http://operaton.x.maxistar.me/ from foked repository.

Here is how to set this up: 

Set the following secrets in your GitHub repository (Settings > Secrets and variables > Actions):

SSH_USER — SSH username
SSH_HOST — SSH hostname (e.g. [example.com](https://docs.operaton.org/))
SSH_PORT — SSH port (e.g. 22)
SSH_PATH — Path on server where you want to deploy (e.g. /var/www/operaton-documenation/html/)

setup SSH_KEY:

`ssh-keygen -t rsa -b 4096 -C "github-actions-deploy" -f docusaurus_deploy_key``

`cat docusaurus_deploy_key.pub`

on remote server:

````
mkdir -p ~/.ssh
nano ~/.ssh/authorized_keys
# Paste the public key here
chmod 600 ~/.ssh/authorized_keys
````

- copy private key `cat docusaurus_deploy_key`
- in gihub: Settings > Secrets and variables > Actions
- Add a new secret named: SSH_PRIVATE_KEY

once pipeline is merged to main branch you can trigger it manually.

this PR closes #2
