### PR TITLE
updated docker image tag name and added link to docker hub page

### DIFF
--- a/docs/get-started/quick-start/install.md
+++ b/docs/get-started/quick-start/install.md
@@ -12,11 +12,13 @@ In the following section, we'll describe how to install the Operaton Platform lo
 If you prefer, you can also run the Operaton Platform with Docker:
 
 ```sh
-docker pull operaton/operaton:run-latest
+docker pull operaton/operaton:latest
 docker run -d --name camunda -p 8080:8080 operaton/operaton:run-latest
 ```
 
 Afterwards, you can [install the Camunda Modeler](#camunda-modeler).
+
+[More information regarding the docker image](https://hub.docker.com/r/operaton/operaton)
 :::
 
 


### PR DESCRIPTION
The docker tag name is no longer existant. Fixed this. Added url to docker hub page, so if tag or image name is wrong in the future again at least a link to the image documentation is available.