### PR TITLE
Fix inconsistent docker commands in install.md

### DIFF
--- a/docs/get-started/quick-start/install.md
+++ b/docs/get-started/quick-start/install.md
@@ -13,7 +13,7 @@ If you prefer, you can also run the Operaton Platform with Docker:
 
 ```sh
 docker pull operaton/operaton:latest
-docker run -d --name camunda -p 8080:8080 operaton/operaton:run-latest
+docker run -d --name camunda -p 8080:8080 operaton/operaton:latest
 ```
 
 Afterwards, you can [install the Camunda Modeler](#camunda-modeler).


### PR DESCRIPTION
Fix inconsistent docker image name in `docker run` command (which was not working). The image name was not the same as in the command before.