### PR TITLE
chore(deps): update operaton-bpm-spring-boot-starter version to 1.0.0

### DIFF
--- a/docs/documentation/user-guide/spring-boot-integration/index.md
+++ b/docs/documentation/user-guide/spring-boot-integration/index.md
@@ -18,11 +18,11 @@ To enable Operaton auto configuration, add the following dependency to your ```p
 <dependency>
   <groupId>org.operaton.bpm.springboot</groupId>
   <artifactId>operaton-bpm-spring-boot-starter</artifactId>
-  <version>1.0.0-rc-1</version>
+  <version>1.0.0</version>
 </dependency>
 ```
 
-This will add the Operaton engine v1.0.0-rc-1 to your dependencies.
+This will add the Operaton engine v1.0.0 to your dependencies.
 
 Other starters that can be used are: 
 


### PR DESCRIPTION
This PR updates the Spring Boot integration documentation to reflect current Operaton versioning and bumps the Operaton Spring Boot Starter reference to 1.0.0. 