### PR TITLE
Align docs with open source edition wording

### DIFF
--- a/docs/documentation/installation/docker.md
+++ b/docs/documentation/installation/docker.md
@@ -15,5 +15,5 @@ To start [Operaton](../user-guide/operaton-bpm-run.md) execute the following com
 
 ```shell
 docker pull operaton/operaton:latest
-docker run -d --name Operaton-p 8080:8080 operaton/operaton:latest
+docker run -d --name operaton -p 8080:8080 operaton/operaton:latest
 ```

--- a/docs/documentation/installation/docker.md
+++ b/docs/documentation/installation/docker.md
@@ -7,7 +7,7 @@ description: "Run the Full Distribution using Docker"
 ---
 ## Run Operaton using Docker
 
-The Community Edition docker images can be found on [Docker Hub](https://hub.docker.com/r/operaton/operaton/).
+The Docker images can be found on [Docker Hub](https://hub.docker.com/r/operaton/operaton/).
 
 ### Start Operaton using Docker
 

--- a/docs/documentation/introduction/extensions.md
+++ b/docs/documentation/introduction/extensions.md
@@ -10,11 +10,11 @@ menu:
 
 ---
 
-Operaton is developed as an open source project in collaboration with the community. The core Operaton product is open source.
+Operaton is developed as an open source project in collaboration with the community. Operaton does not have separate editions; the product is open source.
 
 ## Extensions
 
-Operaton supports the community in its effort to build additional community extensions under the Operaton umbrella. Such community extensions are maintained by the community and are not part of the core Operaton distribution.
+Operaton supports the community in its effort to build additional community extensions under the Operaton umbrella. Such community extensions are maintained by the community and are not part of the official Operaton distribution.
 
 The [Operaton Community Hub](https://github.com/operaton-community-hub) is a GitHub organization that serves as the home of Operaton open source, community-contributed extensions. You can migrate an extension you've built to the Hub, search for existing extensions, or get started with open source by helping community extension maintainers with open issue or pull request triage.
 

--- a/docs/documentation/introduction/extensions.md
+++ b/docs/documentation/introduction/extensions.md
@@ -10,11 +10,11 @@ menu:
 
 ---
 
-Operaton is developed by Operaton as an open source project in collaboration with the community. This is the basis for the Operaton product provided by Operaton as a commercial offering.
+Operaton is developed as an open source project in collaboration with the community. The core Operaton product is open source.
 
 ## Extensions
 
-Operaton supports the community in its effort to build additional community extensions under the Operaton umbrella. Such community extensions are maintained by the community and are not part of the commercial Operaton product.
+Operaton supports the community in its effort to build additional community extensions under the Operaton umbrella. Such community extensions are maintained by the community and are not part of the core Operaton distribution.
 
 The [Operaton Community Hub](https://github.com/operaton-community-hub) is a GitHub organization that serves as the home of Operaton open source, community-contributed extensions. You can migrate an extension you've built to the Hub, search for existing extensions, or get started with open source by helping community extension maintainers with open issue or pull request triage.
 

--- a/docs/documentation/user-guide/process-engine/authorization-service.md
+++ b/docs/documentation/user-guide/process-engine/authorization-service.md
@@ -723,7 +723,7 @@ retrieve the entities related to the Historic Process Instance:
 ### System permissions
 
 Permissions for the system resource are usually granted to operations engineers who supervise processes and applications and ensure they run smoothly from a technical perspective.
-Typically, those people do not need full access to the system like an administrator does. They must be able to access and change system information, including system properties, metrics, database information, telemetry, and license key data. Administrators will not need to have system permissions because their role already grants them access to all features. See also the <a href="#Administrators">Administrators</a> section.
+Typically, those people do not need full access to the system like an administrator does. They must be able to access and change system information, including system properties, metrics, database information, and telemetry. Administrators will not need to have system permissions because their role already grants them access to all features. See also the <a href="#Administrators">Administrators</a> section.
 
 The following table gives an overview of the features that the system permissions grant access to.
 
@@ -793,24 +793,6 @@ The following table gives an overview of the features that the system permission
     </tr>
     <tr>
       <th>Delete Property</th>
-      <td></td>
-      <td></td>
-      <td>X</td>
-    </tr>
-    <tr>
-      <th>Get License Key</th>
-      <td>X</td>
-      <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <th>Set License Key</th>
-      <td></td>
-      <td>X</td>
-      <td></td>
-    </tr>
-    <tr>
-      <th>Delete License Key</th>
       <td></td>
       <td></td>
       <td>X</td>

--- a/docs/documentation/user-guide/process-engine/diagnostics-data.md
+++ b/docs/documentation/user-guide/process-engine/diagnostics-data.md
@@ -45,7 +45,7 @@ The "General Data" category contains information about the process engine:
 * Installation - an id that is stored as process engine configuration property
 * Product name - the name of the product (i.e., `Operaton BPM Runtime`)
 * Product version - the version of the process engine (i.e., `7.X.Y`)
-* Product edition - the edition of the product (i.e., `community` or `enterprise`)
+* Product edition - a legacy compatibility field. Operaton is open source and reports `community`.
 
 ### Meta and environment data
 The "Meta/Environment Data" category contains information about the environmental setup:
@@ -76,7 +76,7 @@ The counts are collected from the start of the engine or the last reported time 
     "product": {
       "name": "Operaton BPM Runtime",
       "version": "7.14.0",
-      "edition": "enterprise",
+      "edition": "community",
       "internals": {
         "database": {
           "vendor": "h2",
@@ -105,16 +105,6 @@ The counts are collected from the start of the engine or the last reported time 
           "spring-boot-starter",
           "operaton-bpm-run"
         ],
-        "license-key": {
-          "customer": "customer name",
-          "type": "UNIFIED",
-          "valid-until": "2022-09-30",
-          "unlimited": false,
-          "features": {
-            "camundaBPM": "true"
-          },
-          "raw": "customer=customer name;expiryDate=2022-09-30;camundaBPM=true;optimize=false;cawemo=false"
-        },
         "webapps": [
           "cockpit",
           "admin"

--- a/docs/documentation/user-guide/process-engine/diagnostics-data.md
+++ b/docs/documentation/user-guide/process-engine/diagnostics-data.md
@@ -45,6 +45,7 @@ The "General Data" category contains information about the process engine:
 * Installation - an id that is stored as process engine configuration property
 * Product name - the name of the product (i.e., `Operaton BPM Runtime`)
 * Product version - the version of the process engine (i.e., `7.X.Y`)
+* Product edition - the edition of the product (i.e., `community` or `enterprise`)
 
 ### Meta and environment data
 The "Meta/Environment Data" category contains information about the environmental setup:
@@ -56,7 +57,7 @@ The "Meta/Environment Data" category contains information about the environmenta
 
 The application server information cannot be obtained in an embedded process engine setup where no web application (e.g. Tasklist, Cockpit, REST application) is deployed and used.
 
-In case of Azul Zulu JDK, the vendor will be send as "Oracle Corporation" as it cannot be distinguished programmatically from an Oracle JDK.
+In case of Azul Zulu JDK, the vendor will be sent as "Oracle Corporation" as it cannot be distinguished programmatically from an Oracle JDK.
 
 
 ### Usage data
@@ -75,7 +76,7 @@ The counts are collected from the start of the engine or the last reported time 
     "product": {
       "name": "Operaton BPM Runtime",
       "version": "7.14.0",
-      "edition": "tbd",
+      "edition": "enterprise",
       "internals": {
         "database": {
           "vendor": "h2",
@@ -99,7 +100,7 @@ The counts are collected from the start of the engine or the last reported time 
           "decision-instances": { "count": 140 },
           "executed-decision-elements": { "count": 732 }
         },
-        "data-collection-start-date": "2022-11-320T15:53:20.386+0100",
+        "data-collection-start-date": "2022-11-30T15:53:20.386+0100",
         "operaton-integration": [
           "spring-boot-starter",
           "operaton-bpm-run"

--- a/docs/documentation/user-guide/process-engine/diagnostics-data.md
+++ b/docs/documentation/user-guide/process-engine/diagnostics-data.md
@@ -45,7 +45,7 @@ The "General Data" category contains information about the process engine:
 * Installation - an id that is stored as process engine configuration property
 * Product name - the name of the product (i.e., `Operaton BPM Runtime`)
 * Product version - the version of the process engine (i.e., `7.X.Y`)
-* Product edition - a legacy compatibility field. Operaton is open source and reports `community`.
+* `edition` - a legacy compatibility field. Operaton does not have separate editions and reports `community` for compatibility.
 
 ### Meta and environment data
 The "Meta/Environment Data" category contains information about the environmental setup:


### PR DESCRIPTION
## Summary
- remove Community Edition wording from the Docker image documentation
- replace commercial/core-product wording with explicit open-source and no-separate-editions language
- document the diagnostics `edition` field as a legacy compatibility value that reports `community`
- remove the license-key sample from the diagnostics example
- remove license-key permission rows from the system permissions documentation
- fix the Docker run example so the container name and `-p` option are separated correctly
- fix an invalid sample timestamp and a small grammar issue in the same diagnostics section

## Verification
- `rg -n -i "enterprise edition|commercial Operaton|commercial offering|commercial product|community edition|license key|license-key|Get License Key|Set License Key|Delete License Key" docs src README.md docusaurus.config.ts package.json` now only returns historical Camunda 7 Community Edition release-note references, not Operaton edition or license-key wording
- `git diff --check`
- `npm run build` succeeds; it reports the known pre-existing Docusaurus link/anchor warnings addressed by follow-up docs quality PRs

References checked:
- https://github.com/operaton/operaton/blob/main/engine/src/main/java/org/operaton/bpm/engine/impl/util/ProcessEngineDetails.java
- https://github.com/operaton/operaton/blob/main/engine/src/main/java/org/operaton/bpm/engine/impl/util/ParseUtil.java
- https://github.com/operaton/operaton/blob/main/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceGetTelemetryDataTest.java
