### PR TITLE
Gate Typesense search on API key

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -7,6 +7,8 @@ import rehypeRegisterCustomIds from './src/plugins/rehype-register-custom-ids.js
 import remarkBpmnDiagram from './src/plugins/remark-bpmn-diagram.js';
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
+const typesenseApiKey = process.env.TYPESENSE_API_KEY?.trim();
+
 const config: Config = {
   title: 'Operaton Documentation',
   tagline: 'BPMN-Process Automation for Everyone',
@@ -73,7 +75,7 @@ const config: Config = {
       } satisfies Preset.Options,
     ],
   ],
-  themes: ['docusaurus-theme-search-typesense'],
+  themes: typesenseApiKey ? ['docusaurus-theme-search-typesense'] : [],
 
   themeConfig: {
     // Replace with your project's social card
@@ -83,27 +85,31 @@ const config: Config = {
         autoCollapseCategories: true,
       },
     },
-    typesense: {
-      typesenseCollectionName: 'docusaurus',
+    ...(typesenseApiKey
+      ? {
+          typesense: {
+            typesenseCollectionName: 'docusaurus',
 
-      typesenseServerConfig: {
-        nodes: [
-          {
-            host: 'docs.operaton.org',
-            port: 8108,
-            protocol: 'https',
+            typesenseServerConfig: {
+              nodes: [
+                {
+                  host: 'docs.operaton.org',
+                  port: 8108,
+                  protocol: 'https',
+                },
+              ],
+              apiKey: typesenseApiKey,
+              sendApiKeyAsQueryParam: false,
+            },
+
+            // Optional: Typesense search parameters: https://typesense.org/docs/0.24.0/api/search.html#search-parameters
+            typesenseSearchParameters: {},
+
+            // Optional
+            contextualSearch: true,
           },
-        ],
-        apiKey: process.env.TYPESENSE_API_KEY ?? 'placeholder',
-        sendApiKeyAsQueryParam: false,
-      },
-
-      // Optional: Typesense search parameters: https://typesense.org/docs/0.24.0/api/search.html#search-parameters
-      typesenseSearchParameters: {},
-
-      // Optional
-      contextualSearch: true,
-    },
+        }
+      : {}),
     navbar: {
       title: 'Operaton',
       logo: {
@@ -129,10 +135,14 @@ const config: Config = {
           position: 'left',
           label: 'Security',
         },
-        {
-          type: 'search',
-          position: 'right',
-        },
+        ...(typesenseApiKey
+          ? [
+              {
+                type: 'search' as const,
+                position: 'right' as const,
+              },
+            ]
+          : []),
         {
           href: 'https://github.com/operaton',
           label: 'GitHub',


### PR DESCRIPTION
## Summary
- remove the hard-coded `placeholder` fallback for the Typesense API key
- enable the Typesense theme, config, and search navbar item only when `TYPESENSE_API_KEY` is set
- keep production/search-enabled builds working with the existing Typesense server settings

## Verification
- `rg -n "placeholder|TYPESENSE_API_KEY|typesenseApiKey|type: 'search'|docusaurus-theme-search-typesense" docusaurus.config.ts -S`\n- `git diff --check`\n- `env -u TYPESENSE_API_KEY npm run build`\n- `TYPESENSE_API_KEY=dummy-search-key npm run build`\n\nBoth builds succeed; remaining broken link/anchor warnings are the known `main` warnings addressed in #115/#118. Ignored generated build/cache artifacts were removed afterward to avoid local ENOSPC issues.\n\nReferences checked:\n- Local `docusaurus-theme-search-typesense` README and theme validation source under `node_modules/docusaurus-theme-search-typesense`\n- https://typesense.org/docs/guide/docsearch.html\n