### PR TITLE
Fix docs typos and articles

### DIFF
--- a/docs/documentation/index.md
+++ b/docs/documentation/index.md
@@ -31,4 +31,4 @@ In case you get stuck on a problem make sure to [ask for Help in the Forums](htt
 
 ## Community Extensions
 
-A number of Community Extensions enhance Operaton with additional capabilities. Browse the Operaton Community Hub for information on building a Operaton Community Extension, discover new Operaton Community Extension open source projects to contribute to, and more.
+A number of Community Extensions enhance Operaton with additional capabilities. Browse the Operaton Community Hub for information on building an Operaton Community Extension, discover new Operaton Community Extension open source projects to contribute to, and more.

--- a/docs/documentation/introduction/downloading-operaton.md
+++ b/docs/documentation/introduction/downloading-operaton.md
@@ -46,7 +46,7 @@ The full distribution bundles
   If you download the full distribution for an open-source application
   server/container, the container itself is included. For example, if you download the Tomcat
   distribution, Tomcat itself is included and the Operaton binaries (process engine and
-  web apps) are pre-installed in the container. This is not true for the the Oracle WebLogic
+  web apps) are pre-installed in the container. This is not true for the Oracle WebLogic
   and IBM WebSphere downloads; these downloads do not include the application servers themselves.
 :::
 

--- a/docs/documentation/reference/bpmn20/custom-extensions/extension-attributes.md
+++ b/docs/documentation/reference/bpmn20/custom-extensions/extension-attributes.md
@@ -1198,7 +1198,7 @@ The following attributes are extension attributes for the `camunda` namespace `h
   <tr>
     <th>Description</th>
     <td>
-      The attribute references a Operaton form definition by its key. See <a href="../user-guide/task-forms/index.md">task forms</a> for more information.
+      The attribute references an Operaton form definition by its key. See <a href="../user-guide/task-forms/index.md">task forms</a> for more information.
     </td>
   </tr>
   <tr>

--- a/docs/documentation/reference/bpmn20/custom-extensions/extension-elements.md
+++ b/docs/documentation/reference/bpmn20/custom-extensions/extension-elements.md
@@ -14,7 +14,7 @@ The following attributes are extension attributes for the `camunda` namespace `h
   <tr>
     <th>Description</th>
     <td colspan="2">
-      The configuration of a Operaton connector.
+      The configuration of an Operaton connector.
     </td>
   </tr>
   <tr>

--- a/docs/documentation/reference/bpmn20/events/conditional-events.md
+++ b/docs/documentation/reference/bpmn20/events/conditional-events.md
@@ -214,7 +214,7 @@ For example, let us assume a variable is set in a start execution listener of an
 ### Top-Down Evaluation
 
 A variable change causes condition evaluation and event triggering in a *top-down* fashion.
-That means the evaluation starts at the the conditional events of the BPMN scope in which the variable was changed. It then step by step descends into the instances of nested BPMN scopes (e.g., embedded sub processes). This is done until a conditional event is triggered that interrupts the current scope instance (thereby cancelling all children) or until there are no more deeper nested scopes.
+That means the evaluation starts at the conditional events of the BPMN scope in which the variable was changed. It then step by step descends into the instances of nested BPMN scopes (e.g., embedded sub processes). This is done until a conditional event is triggered that interrupts the current scope instance (thereby cancelling all children) or until there are no more deeper nested scopes.
 
 For example see the following BPMN process model:
 

--- a/docs/documentation/reference/cmmn11/markers/repetition-rule.md
+++ b/docs/documentation/reference/cmmn11/markers/repetition-rule.md
@@ -102,7 +102,7 @@ In our example, the following steps might take place:
 ![Example img](/img/documentation/reference/cmmn11/markers/state-4.png)
 8. From now on, no more repetitions of *A* can occur.
 
-The transition in which the repetition rule is evaluated can be changed by a Operaton extension attribute named `operaton:repeatOnStandardEvent`. For a task it looks as follows:
+The transition in which the repetition rule is evaluated can be changed by an Operaton extension attribute named `operaton:repeatOnStandardEvent`. For a task it looks as follows:
 
 ```xml
 <definitions>

--- a/docs/documentation/reference/deployment-descriptors/tags/process-archive.md
+++ b/docs/documentation/reference/deployment-descriptors/tags/process-archive.md
@@ -244,7 +244,7 @@ The following is a list of all supported configuration properties.
                  </pre>
              If the process archive(s) defined in (1) uses a path prefixed with <code>pa:</code>, like for instance <code>pa:opps/</code>,
              only the <code>opps/</code>-folder of sales-processes.jar is scanned. More precisely, a "pa-local path", is resolved
-             relative to the the parent directory of the META-INF-directory containing the defining processes.xml file.
+             relative to the parent directory of the META-INF-directory containing the defining processes.xml file.
              This implies that when using a pa-local path in (1), no processes from (2) are visible.
             </li>
           </ul>

--- a/docs/documentation/reference/deployment-descriptors/tags/process-archive.md
+++ b/docs/documentation/reference/deployment-descriptors/tags/process-archive.md
@@ -253,7 +253,7 @@ The following is a list of all supported configuration properties.
   </tr>
   <tr>
     <td><code>additionalResourceSuffixes</code></td>
-    <td>comma-seperated list</td>
+    <td>comma-separated list</td>
     <td>
       Specifies a list of additional suffixes which are considered as deployment resource if the
       <code>isScanForProcessDefinitions</code> property is set to <code>true</code>. It can be used

--- a/docs/documentation/update/index.md
+++ b/docs/documentation/update/index.md
@@ -10,6 +10,6 @@ menu:
 
 ---
 
-These documents provide instructions to update a Java Project or a Operaton installation to a new version.
+These documents provide instructions to update a Java Project or an Operaton installation to a new version.
 
 Depending on which update you want to perform, choose one of the following guides:

--- a/docs/documentation/user-guide/cdi-java-ee-integration/jta-transaction-integration.md
+++ b/docs/documentation/user-guide/cdi-java-ee-integration/jta-transaction-integration.md
@@ -50,7 +50,7 @@ public class MyBean {
   @Transactional
   public void doSomethingTransactional() {
     // Here you can do transactional stuff in your domain model and it will be
-    // combined in the same transaction as the the following RuntimeService API
+    // combined in the same transaction as the following RuntimeService API
     // call to start a process instance:
     runtimeService.startProcessInstanceByKey("my-process");
   }
@@ -61,7 +61,7 @@ public class MyBean {
 ## Using JTA transaction integration with WebSphere Liberty
 
 Operaton allows to mark a transaction as "rollback only" by calling `UserTransaction#setRollbackOnly()`.
-If this code is executed within a Operaton Job, the Job is marked as failed, and can be retried.
+If this code is executed within an Operaton job, the job is marked as failed, and can be retried.
 
 WebSphere Liberty doesn't support this behavior of Operaton. When calling `UserTransaction#setRollbackOnly()`
 in WebSphere Liberty, the transaction is rolled back silently, and the Operaton process engine is unable to unlock the

--- a/docs/documentation/user-guide/dmn-engine/data-types.md
+++ b/docs/documentation/user-guide/dmn-engine/data-types.md
@@ -66,7 +66,7 @@ The following types are supported by the DMN engine:
 </table>
 
 Each data type transformer produces a typed value which contains the value and
-additional type informations.
+additional type information.
 
 If the given type does not match one of the above types then the value is
 transformed into an untyped value by default.
@@ -74,7 +74,7 @@ transformed into an untyped value by default.
 ### Working with Dates
 
 The DMN engine supports a `date` type which is a combination of date and time.
-By default, the data type transformer accept objects of the types:
+By default, the data type transformers accept objects of the types:
 
 * `java.util.Date`
 * Strings having the format `yyyy-MM-dd'T'HH:mm:ss`

--- a/docs/documentation/user-guide/dmn-engine/feel/legacy-behavior.md
+++ b/docs/documentation/user-guide/dmn-engine/feel/legacy-behavior.md
@@ -12,7 +12,7 @@ menu:
 
 ---
 
-If you come from a Operaton version $\leq$ 7.12.x and already use FEEL, it might be that you need to
+If you come from an Operaton version $\leq$ 7.12.x and already use FEEL, it might be that you need to
 migrate your DMN models. To do this, please check out the [Migration Guide], where we've documented
 all breaking changes.
 

--- a/docs/documentation/user-guide/process-applications/process-application-resources.md
+++ b/docs/documentation/user-guide/process-applications/process-application-resources.md
@@ -39,7 +39,7 @@ Process application context must be declared whenever custom code uses the engin
 
 ### Example
 
-To clarify the use case, we assume that a process application employs the [feature to serialize object-type variables in the JSON format](../../user-guide/data-formats/json.md#serializing-process-variables). However, for that application JSON serialization shall be customized (think about the numerous ways to serialize a date as a JSON string). The process application therefore contains a Operaton Spin data format configurator implementation that configures the Spin JSON data format in the desired way. In turn, the process engine manages a Spin data format for that specific process application to serialize object values with. Now, we assume that a Java servlet calls the process engine API to submit a Java object and serialize it with the JSON format. The code might look as follows:
+To clarify the use case, we assume that a process application employs the [feature to serialize object-type variables in the JSON format](../../user-guide/data-formats/json.md#serializing-process-variables). However, for that application JSON serialization shall be customized (think about the numerous ways to serialize a date as a JSON string). The process application therefore contains an Operaton Spin data format configurator implementation that configures the Spin JSON data format in the desired way. In turn, the process engine manages a Spin data format for that specific process application to serialize object values with. Now, we assume that a Java servlet calls the process engine API to submit a Java object and serialize it with the JSON format. The code might look as follows:
 
 ```java
 public class ObjectValueServlet extends HttpServlet {

--- a/docs/documentation/user-guide/process-engine/identity-service.md
+++ b/docs/documentation/user-guide/process-engine/identity-service.md
@@ -346,7 +346,7 @@ The LDAP Identity Provider provides the following configuration properties:
         <em>Default:</em> <code>false</code>
       </p>
       <p>
-        <strong>Note:</strong> The support of search result ordering is not be implemented by every LDAP server.
+        <strong>Note:</strong> Support for search result ordering is not implemented by every LDAP server.
         Make sure that your currently used LDAP Server implements the <a href="https://tools.ietf.org/html/rfc2891">RFC 2891</a>.
       </p>
     </td>

--- a/docs/documentation/user-guide/process-engine/process-engine-concepts.md
+++ b/docs/documentation/user-guide/process-engine/process-engine-concepts.md
@@ -140,7 +140,7 @@ ProcessInstanceWithVariables instance = runtimeService.createProcessInstanceByKe
   .executeWithVariablesInReturn();
 ```
 
-The `executeWithVariablesInReturn` returns if the process instance ends or reaches a wait state. The returned `ProcessInstanceWithVariables` object contains the informations of the process instance and the latest variables.
+The `executeWithVariablesInReturn` returns if the process instance ends or reaches a wait state. The returned `ProcessInstanceWithVariables` object contains the information of the process instance and the latest variables.
 
 ### Query for Process Instances
 

--- a/docs/documentation/user-guide/runtime-container-integration/tomcat.md
+++ b/docs/documentation/user-guide/runtime-container-integration/tomcat.md
@@ -52,7 +52,7 @@ Furthermore, declare the dependency on the JNDI binding inside the `WEB-INF/web.
 
 **Note**: You can choose different resource link names for the Process Engine Service and Process Application Service. The resource link name has to match the value inside the `<res-ref-name>`-element inside the corresponding `<resource-ref>`-element in `WEB-INF/web.xml`. We propose the name `ProcessEngineService` for the Process Engine Service and `ProcessApplicationService` for the Process Application Service.
 
-To do a lookup for a Operaton Service you have to use the resource link name to get the linked global resource. For example:
+To do a lookup for an Operaton service you have to use the resource link name to get the linked global resource. For example:
 
 * Process Engine Service: `java:comp/env/ProcessEngineService`
 * Process Application Service: `java:comp/env/ProcessApplicationService`

--- a/docs/documentation/user-guide/task-forms/index.md
+++ b/docs/documentation/user-guide/task-forms/index.md
@@ -96,7 +96,7 @@ Forms can be used on top of the task completion API to render form fields and va
 
 ### Form Reference
 
-With Form References, Operaton Forms provide a flexible way of linking an element in a BPMN diagram to a form. To link a BPMN element ([StartEvent][start-event] or [UserTask][user-tasks]) to a Operaton Form, you have to specify the Id of the Operaton Form as the `operaton:formRef` attribute. Additionally, the `operaton:formRefBinding` attribute specifies which version of the Operaton Form to reference.
+With Form References, Operaton Forms provide a flexible way of linking an element in a BPMN diagram to a form. To link a BPMN element ([StartEvent][start-event] or [UserTask][user-tasks]) to an Operaton Form, you have to specify the Id of the Operaton Form as the `operaton:formRef` attribute. Additionally, the `operaton:formRefBinding` attribute specifies which version of the Operaton Form to reference.
 
 Valid values are:
 
@@ -128,7 +128,7 @@ The attributes `operaton:formRef` and `operaton:formRefVersion` can be specified
 
 ### Form Key
 
-Aa an alternative to `formRef` you can reference a Operaton Form file with a `deployment` or `app` [form key](../../user-guide/task-forms/index.md#form-key-details):
+As an alternative to `formRef` you can reference an Operaton Form file with a `deployment` or `app` [form key](../../user-guide/task-forms/index.md#form-key-details):
 
 * `operaton-forms:deployment:FORM_NAME.form`
 * `operaton-forms:app:forms/FORM_NAME.form`

--- a/docs/documentation/webapps/tasklist/user-assignment.md
+++ b/docs/documentation/webapps/tasklist/user-assignment.md
@@ -22,14 +22,14 @@ This works as follows:
 
 ![Example img](/img/documentation/webapps/tasklist/tasklist-task-form-modeler.png)User Task Assignment
 
-You can read up on how to implement the inital user assignment for BPMN User Tasks and CMMN Human Tasks in the corresponding reference sections:
+You can read up on how to implement the initial user assignment for BPMN User Tasks and CMMN Human Tasks in the corresponding reference sections:
 
 * [Implementing user assignments for BPMN User Tasks][bpmn-user-assignment]
 * [Implementing user assignments for CMMN Human Tasks][cmmn-user-assignment]
 
 ## Claiming a task in Tasklist
 
-In Tasklist, a user can ony work on a task (i.e., filling in the task form) if the task is assigned to that user. This means that a user must `claim` a task if it is not yet assigned to him.
+In Tasklist, a user can only work on a task (i.e., filling in the task form) if the task is assigned to that user. This means that a user must `claim` a task if it is not yet assigned to him.
 Claiming a task sets the assignee of the task to the user who claimed the task.
 
 See the [Claiming, unclaiming and reassigning tasks](../tasklist/dashboard.md#claim-unclaim-and-reassign-tasks) section for more information.

--- a/docs/get-started/quick-start/decision-automation.md
+++ b/docs/get-started/quick-start/decision-automation.md
@@ -24,7 +24,7 @@ Save your changes and deploy the updated process using the `Deploy` Button in th
 First, create a new DMN diagram by clicking *File > New File > DMN Diagram*.
 ![Example image](/img/get-started/quick-start/modeler-new-dmn-diagram.png)
 
-Now the newly created diagram will already have a decision element added to it. Select it by clicking it and then give it a name of *Approve Payment* and an ID of `approve-payment` (the decision ID must match the the `Decision Ref` in your BPMN process).
+Now the newly created diagram will already have a decision element added to it. Select it by clicking it and then give it a name of *Approve Payment* and an ID of `approve-payment` (the decision ID must match the `Decision Ref` in your BPMN process).
 ![Example image](/img/get-started/quick-start/modeler-new-dmn-diagram-properties.png)
 
 Next, create a new DMN table by clicking the table button.

--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -6,6 +6,6 @@ sidebar_position: 1
 
 This page describes Operaton (also referred to as the 'software') from a security perspective. It has two parts:
 
-* **Instructions for operating the software securely:** Provides an overview of how to secure a Operaton installation. In order to secure a Operaton installation, Operaton itself must be configured correctly and it must be integrated correctly into its environment. This section also identifies areas where we consider security issues to be relevant for the specific Operaton product and listed those in the subsequent sections. Compliance for those areas is ensured based on common industry best practices and influenced by security requirements of standards like OWASP Top 10 and others. 
+* **Instructions for operating the software securely:** Provides an overview of how to secure an Operaton installation. In order to secure an Operaton installation, Operaton itself must be configured correctly and it must be integrated correctly into its environment. This section also identifies areas where we consider security issues to be relevant for the specific Operaton product and lists those in the subsequent sections. Compliance for those areas is ensured based on common industry best practices and influenced by security requirements of standards like OWASP Top 10 and others.
 
-* **Reporting a Vulnerability:** Explains how to report a security vulnerability to Operaton Community. 
+* **Reporting a Vulnerability:** Explains how to report a security vulnerability to Operaton Community.


### PR DESCRIPTION
## Summary
- fix repeated words, misspellings, and article usage across the docs
- clean up a few small grammar issues in the same touched sentences
- fix the `comma-separated list` spelling in the process archive descriptor reference
- restore final newlines in touched Markdown files where missing

## Verification
- `rg -n "\\ba Operaton\\b|\\bthe the\\b|\\binital\\b|\\bformated\\b|\\binformations\\b|\\bis not be\\b|\\bAa an\\b|\\bony work\\b|seperated" $(git diff --name-only main...HEAD) -S` returned no matches
- `rg -n "seperated|comma-separated list" docs/documentation/reference/deployment-descriptors/tags/process-archive.md -S` reports only the corrected `comma-separated list`
- `git diff --check`
- `npm run build` succeeds; it reports the known pre-existing `main` link/anchor warnings covered by separate docs quality work

Note: remaining typo-like matches outside this PR are either historical/release-note text, intentional wording, or are already covered by other open PRs touching the same docs areas.
