### PR TITLE
Harden deploy build workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,13 +19,13 @@ jobs:
           node-version: '20'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build Operaton site
         env:
           TYPESENSE_API_KEY: ${{ secrets.TYPESENSE_API_KEY }}
         run: |
-          npm run build || echo "Build failed, proceeding anyway if build/ exists"
+          npm run build
           .github/script/release-assets.sh
 
       - name: Check if build directory exists


### PR DESCRIPTION
## Summary
- use `npm ci` in the deploy workflow for lockfile-based installs
- make `npm run build` fail the deploy job instead of continuing after a build failure
- keep release asset preparation after a successful site build

## Verification
- `npm ci`
- `npm run build` succeeds; it reports the known pre-existing `main` link/anchor warnings covered by separate docs quality work
- `git diff --check`

Note: Dependabot PR #113 also touches this workflow to bump `actions/checkout`, but this PR only changes the install/build steps.
