### PR TITLE
Fix BPMN extension reference wording

### DIFF
--- a/docs/documentation/reference/bpmn20/custom-extensions/index.md
+++ b/docs/documentation/reference/bpmn20/custom-extensions/index.md
@@ -7,8 +7,8 @@ sidebar_position: 50
 
 # Extension Reference
 
-Camunda extends BPMN with custom Extension Elements and Attributes.
+Operaton extends BPMN with custom extension elements and attributes.
 
-* [Extension Elements](./extension-elements.md) Reference of Camunda Extension Attributes for BPMN.
+* [Extension Elements](./extension-elements.md) Reference of Operaton extension elements for BPMN.
 
-* [Extension Attributes](./extension-attributes.md) Reference of Camunda Extension Attributes for BPMN.
+* [Extension Attributes](./extension-attributes.md) Reference of Operaton extension attributes for BPMN.


### PR DESCRIPTION
## Summary
- replace leftover Camunda product wording in the BPMN custom extension overview
- clarify that the extension elements page documents elements and the extension attributes page documents attributes

## Verification
- `rg -n "Camunda extends|Camunda Extension|Reference of Camunda" docs/documentation/reference/bpmn20/custom-extensions/index.md -S` returned no matches
- `git diff --check`
- `npm run build` succeeds; it reports the known pre-existing `main` link/anchor warnings covered by separate docs quality work
