### PR TITLE
Align quick start deployment with Operaton

### DIFF
--- a/docs/get-started/quick-start/decision-automation.md
+++ b/docs/get-started/quick-start/decision-automation.md
@@ -10,11 +10,11 @@ description: "Learn how to integrate DMN decision tables in the Process."
 In this section, you'll learn how to add decision automation to your process by using [BPMN 2.0 *Business Rule Tasks*](/docs/documentation/reference/bpmn20/tasks/business-rule-task/) and [DMN 1.3 Decision Tables](/docs/documentation/reference/dmn/).
 
 ## Add a Business Rule Task to the Process
-Use the Operaton Modeler to open the Payment Retrieval process then click on the Approve Payment Task. Change the activity type to *Business Rule Task* in the wrench button menu.
+Use the Operaton Modeler to open the Payment Retrieval process, then click the Approve Payment Task. Change the activity type to *Business Rule Task* in the wrench button menu.
 
 ![Example image](/img/get-started/quick-start/modeler-businessrule-task1.png)
 
-Next, link the Business Rule Task to a DMN table by changing `Implementation` to `DMN` and `Decision Ref` to `approve-payment` in the properties panel. In order to retrieve the result of the evaluation and save it automatically as a process instance variable in our process, we also need to change the `Result Variable` to `approved` and use `singleEntry` as the `Map Decision Result` in the properties panel.
+Next, link the Business Rule Task to a DMN table by changing `Implementation` to `DMN` and `Decision Ref` to `approve-payment` in the properties panel. To retrieve the result of the evaluation and save it automatically as a process instance variable in our process, we also need to change the `Result Variable` to `approved` and use `singleEntry` as the `Map Decision Result` in the properties panel.
 
 ![Example image](/img/get-started/quick-start/modeler-businessrule-task2.png)
 
@@ -46,7 +46,7 @@ After setup, your DMN table should look like this:
 ![Example image](/img/get-started/quick-start/modeler-dmn5.png)
 
 ## Deploy the DMN table
-To deploy the Decision Table, click on the Deploy button in the Operaton Modeler, give it Deployment Name "Payment Retrieval Decision", then hit the Deploy button.
+To deploy the decision table, click the Deploy button in the Operaton Modeler, give it the deployment name "Payment Retrieval Decision", then click the Deploy button.
 ![Example image](/img/get-started/quick-start/modeler-dmn6.png)
 
 ## Verify the Deployment with Cockpit
@@ -56,7 +56,7 @@ Now, use Cockpit to see if the decision table was successfully deployed. Go to [
 
 ## Inspect using Cockpit and Tasklist
 
-Next, use Tasklist to start two new Process Instances and verify that depending on your input, the Process Instance will be routed differently.
+Next, use Tasklist to start two new process instances and verify that depending on your input, the process instance will be routed differently.
 To do so, go to [http://localhost:8080/operaton/app/tasklist/](http://localhost:8080/operaton/app/tasklist/). Log in with *demo / demo*.
 
 Click on the Start process button to start a process instance and choose the `Payment` process.
@@ -70,7 +70,7 @@ Use the generic form to add the variables as follows:
 ![Example image](/img/get-started/quick-start/tasklist-dmn2.png)
 
 You'll see that depending on the input, the worker will either charge or not charge the credit card.
-You can also verify that the DMN tables were evaluated by using Operaton Cockpit. Go to [http://localhost:8080/operaton/app/cockpit/](http://localhost:8080/operaton/app/cockpit/). Log in with the credentials *demo / demo*. Navigate to the "Decisions" section and click on Approve Payment. Check the different Decision Instances that were evaluated by clicking on the ID in the table.
+You can also verify that the DMN tables were evaluated by using Operaton Cockpit. Go to [http://localhost:8080/operaton/app/cockpit/](http://localhost:8080/operaton/app/cockpit/). Log in with the credentials *demo / demo*. Navigate to the "Decisions" section and click on Approve Payment. Check the different decision instances that were evaluated by clicking on the ID in the table.
 
 A single DMN table that was executed could look like this in Operaton Cockpit:
 ![Example image](/img/get-started/quick-start/cockpit-dmn-table.png)

--- a/docs/get-started/quick-start/decision-automation.md
+++ b/docs/get-started/quick-start/decision-automation.md
@@ -76,5 +76,5 @@ A single DMN table that was executed could look like this in Operaton Cockpit:
 ![Example image](/img/get-started/quick-start/cockpit-dmn-table.png)
 
 :::note[Success!]
-Congratulations! You've successfully completed the Operaton Platform Quick Start. Ready to continue? We recommend the [Operaton Platform documentation](https://docs.operaton.org/docs/documentation/).
+Congratulations! You've successfully completed the Operaton Platform Quick Start. Ready to continue? We recommend the [Operaton Platform documentation](/docs/documentation/).
 :::

--- a/docs/get-started/quick-start/decision-automation.md
+++ b/docs/get-started/quick-start/decision-automation.md
@@ -10,7 +10,7 @@ description: "Learn how to integrate DMN decision tables in the Process."
 In this section, you'll learn how to add decision automation to your process by using [BPMN 2.0 *Business Rule Tasks*](/docs/documentation/reference/bpmn20/tasks/business-rule-task/) and [DMN 1.3 Decision Tables](/docs/documentation/reference/dmn/).
 
 ## Add a Business Rule Task to the Process
-Use the Camunda Modeler to open the Payment Retrieval process then click on the Approve Payment Task. Change the activity type to *Business Rule Task* in the wrench button menu.
+Use the Operaton Modeler to open the Payment Retrieval process then click on the Approve Payment Task. Change the activity type to *Business Rule Task* in the wrench button menu.
 
 ![Example image](/img/get-started/quick-start/modeler-businessrule-task1.png)
 
@@ -18,9 +18,9 @@ Next, link the Business Rule Task to a DMN table by changing `Implementation` to
 
 ![Example image](/img/get-started/quick-start/modeler-businessrule-task2.png)
 
-Save your changes and deploy the updated process using the `Deploy` Button in the Camunda Modeler.
+Save your changes and deploy the updated process using the `Deploy` button in the Operaton Modeler.
 
-## Create a DMN table using the Camunda Modeler
+## Create a DMN table using the Operaton Modeler
 First, create a new DMN diagram by clicking *File > New File > DMN Diagram*.
 ![Example image](/img/get-started/quick-start/modeler-new-dmn-diagram.png)
 
@@ -46,7 +46,7 @@ After setup, your DMN table should look like this:
 ![Example image](/img/get-started/quick-start/modeler-dmn5.png)
 
 ## Deploy the DMN table
-To deploy the Decision Table, click on the Deploy button in the Camunda Modeler, give it Deployment Name "Payment Retrieval Decision", then hit the Deploy button.
+To deploy the Decision Table, click on the Deploy button in the Operaton Modeler, give it Deployment Name "Payment Retrieval Decision", then hit the Deploy button.
 ![Example image](/img/get-started/quick-start/modeler-dmn6.png)
 
 ## Verify the Deployment with Cockpit

--- a/docs/get-started/quick-start/deploy.md
+++ b/docs/get-started/quick-start/deploy.md
@@ -10,7 +10,7 @@ description: 'Deploy the Process to Operaton and start your first process instan
 In the next step, you'll deploy the Process and start a new instance so you can see that your simple process is working correctly.
 
 :::note[Deployment Support]
-BPMN diagrams must be created for the process engine they intend to be deployed on. You cannot run a BPMN diagram modeled for Operaton Platform in Operaton Cloud, or vice versa, at this time.
+BPMN diagrams must be created for the process engine they intend to be deployed on. In the Camunda Modeler, make sure the execution platform is set to Operaton Platform before deploying to Operaton.
 :::
 
 ## Use the Camunda Modeler to Deploy the Process

--- a/docs/get-started/quick-start/deploy.md
+++ b/docs/get-started/quick-start/deploy.md
@@ -10,19 +10,19 @@ description: 'Deploy the Process to Operaton and start your first process instan
 In the next step, you'll deploy the Process and start a new instance so you can see that your simple process is working correctly.
 
 :::note[Deployment Support]
-BPMN diagrams must be created for the process engine they intend to be deployed on. In the Camunda Modeler, make sure the execution platform is set to Operaton Platform before deploying to Operaton.
+BPMN diagrams must be created for the process engine they intend to be deployed on. In the Operaton Modeler, make sure the execution platform is set to Operaton Platform before deploying to Operaton.
 :::
 
-## Use the Camunda Modeler to Deploy the Process
+<span id="use-the-camunda-modeler-to-deploy-the-process"></span>
 
-In order to deploy the Process, click on the deploy button in the Camunda Modeler, then give it the Deployment Name "Payment Retrieval" and click the Deploy button. From version 3.0.0 on, you will be required to provide an URL for an Endpoint Configuration along with Deployment Details. This can be either the root endpoint to the REST API (e.g. `http://localhost:8080/engine-rest`) or an exact endpoint to the deployment creation method (e.g. `http://localhost:8080/engine-rest/deployment/create`).
+## Use the Operaton Modeler to Deploy the Process
+
+In order to deploy the process, click on the deploy button in the Operaton Modeler, then give it the Deployment Name "Payment Retrieval" and click the Deploy button. When prompted for an Endpoint Configuration, use either the root endpoint to the REST API (e.g. `http://localhost:8080/engine-rest`) or the exact endpoint to the deployment creation method (e.g. `http://localhost:8080/engine-rest/deployment/create`).
 
 ![Example image](/img/get-started/quick-start/modeler-deploy1.png)
 ![Example image](/img/get-started/quick-start/modeler-deploy2.png)
-You should see a success message in the Camunda Modeler:
+You should see a success message in the Operaton Modeler:
 ![Example image](/img/get-started/quick-start/modeler-deploy3.png)
-
-More details regarding the deployment from Camunda Modeler you can find [here](https://blog.camunda.com/post/2019/01/camunda-modeler-3.0.0-0-released/#completely-reworked-deployment-tool). For Camunda Modeler 2.2.4 and earlier, read [this blog post](https://blog.operaton.com/post/2018/03/camunda-modeler-1120-alpha-3-released/).
 
 ## Verify the Deployment with Cockpit
 

--- a/docs/get-started/quick-start/deploy.md
+++ b/docs/get-started/quick-start/deploy.md
@@ -7,7 +7,7 @@ description: 'Deploy the Process to Operaton and start your first process instan
 ---
 # Deploy the Process (3/6)
 
-In the next step, you'll deploy the Process and start a new instance so you can see that your simple process is working correctly.
+In the next step, you'll deploy the process and start a new instance so you can see that your simple process is working correctly.
 
 :::note[Deployment Support]
 BPMN diagrams must be created for the process engine they intend to be deployed on. In the Operaton Modeler, make sure the execution platform is set to Operaton Platform before deploying to Operaton.
@@ -17,7 +17,7 @@ BPMN diagrams must be created for the process engine they intend to be deployed 
 
 ## Use the Operaton Modeler to Deploy the Process
 
-In order to deploy the process, click on the deploy button in the Operaton Modeler, then give it the Deployment Name "Payment Retrieval" and click the Deploy button. When prompted for an Endpoint Configuration, use either the root endpoint to the REST API (e.g. `http://localhost:8080/engine-rest`) or the exact endpoint to the deployment creation method (e.g. `http://localhost:8080/engine-rest/deployment/create`).
+To deploy the process, click the deploy button in the Operaton Modeler, give it the deployment name "Payment Retrieval", and click the Deploy button. When prompted for an Endpoint Configuration, use either the root endpoint to the REST API (e.g. `http://localhost:8080/engine-rest`) or the exact endpoint to the deployment creation method (e.g. `http://localhost:8080/engine-rest/deployment/create`).
 
 ![Example image](/img/get-started/quick-start/modeler-deploy1.png)
 ![Example image](/img/get-started/quick-start/modeler-deploy2.png)
@@ -34,7 +34,7 @@ Next, use Cockpit to see if the process was successfully deployed. Go to [http:/
 ## Start a Process Instance
 
 In Operaton, there are different ways to start a new process instance.
-You can leverage the Operaton REST API to start a new process instance by sending a POST Request.
+You can leverage the Operaton REST API to start a new process instance by sending a POST request.
 
 ### a) curl
 
@@ -52,7 +52,7 @@ If you don't feel comfortable using curl for the REST request, you can instead m
 Make a POST request to the following endpoint:
 `http://localhost:8080/engine-rest/process-definition/key/payment-retrieval/start`
 
-The JSON Body should look like this:
+The JSON body should look like this:
 ```JSON
 {
 	"variables": {
@@ -77,5 +77,5 @@ In your worker console (which we started in the previous section), you should no
 This means you have successfully started and executed your first simple process.
 
 :::note[Next Step]
-In some cases, we'll want to involve humans in our process. Move onto the next step to [learn how you can involve humans in your process](/docs/get-started/quick-start/user-task/).
+In some cases, we'll want to involve humans in our process. Move on to the next step to [learn how you can involve humans in your process](/docs/get-started/quick-start/user-task/).
 :::

--- a/docs/get-started/quick-start/gateway.md
+++ b/docs/get-started/quick-start/gateway.md
@@ -53,7 +53,7 @@ Next, set variables for the process instance using the generic form as we learne
 
 ![Example image](/img/get-started/quick-start/start-form-generic.png)
 
-Fill in the form as shown in the screenshot and make sure you use an amount that is larger or equal to 1000 in order to see the User Task *Approve Payment*.
+Fill in the form as shown in the screenshot and make sure you use an amount that is greater than or equal to 1000 in order to see the User Task *Approve Payment*.
 When you are done, click *Start*.
 
 You should see the *Approve Payment* task when you click on *All Tasks*. In this quick start, we're logged into Tasklist as an admin user, and so we can see all tasks associated with our processes. However, it's possible to create [filters in Tasklist](/docs/documentation/webapps/tasklist/filters/) to determine which users can see which tasks based on [user authorization](/docs/documentation/webapps/admin/authorization-management/) as well as other criteria.
@@ -64,5 +64,5 @@ We should see that our worker prints something to the console.
 Next, repeat the same steps, and this time, reject the payment. You should also create one instance with an amount less than 1000 to confirm that the first gateway works correctly.
 
 :::note[Next Step]
-Now you're ready for Decision Automation. Let's have a look how you can [add Business Rules to your Process](/docs/get-started/quick-start/decision-automation/).
+Now you're ready for Decision Automation. Let's look at how you can [add Business Rules to your Process](/docs/get-started/quick-start/decision-automation/).
 :::

--- a/docs/get-started/quick-start/gateway.md
+++ b/docs/get-started/quick-start/gateway.md
@@ -25,7 +25,7 @@ Now also name the new elements accordingly:
 
 Next, open the properties panel and select the `<1000 €` Sequence Flow after the Gateway on the canvas. This will update the selection in the properties panel.
 Scroll to the property named `Condition Type` and change it to `Expression`. Then input `${amount<1000}` as the Expression.
-We are using the [Java Unified Expression Language](https://docs.operaton.org/docs/documentation/user-guide/process-engine/expression-language/) to evaluate the Gateway.
+We are using the [Java Unified Expression Language](/docs/documentation/user-guide/process-engine/expression-language/) to evaluate the Gateway.
 
 ![Example image](/img/get-started/quick-start/modeler-gateway3.png)
 

--- a/docs/get-started/quick-start/service-task.md
+++ b/docs/get-started/quick-start/service-task.md
@@ -2,12 +2,12 @@
 
 title: 'Executable Process'
 sidebar_position: 2
-description: 'Learn the basics of handling the Camunda Modeler, learn how to model and configure a fully executable process and learn how to integrate your own business logic.'
+description: 'Learn the basics of handling the Operaton Modeler, learn how to model and configure a fully executable process and learn how to integrate your own business logic.'
 
 ---
 # Executing automated steps (2/6)
 
-In this section, you'll learn how to create your first BPMN 2.0 process with the Camunda Modeler and how to execute automated steps. Start by opening up Camunda Modeler.
+In this section, you'll learn how to create your first BPMN 2.0 process with the Operaton Modeler and how to execute automated steps. Start by opening up Operaton Modeler.
 
 ## Create a new BPMN Diagram
 
@@ -39,7 +39,7 @@ Add an End Event named *Payment Received*.
 ### Configure the Service Task
 
 There are different ways to [execute service tasks](https://docs.operaton.org/docs/documentation/reference/bpmn20/tasks/service-task/) using Operaton Platform. In this guide, we'll use the external [task pattern](https://docs.operaton.org/docs/documentation/user-guide/process-engine/external-tasks/).
-Open the Properties Panel within the Camunda Modeler and click on the Service Task you just created. Change the Implementation to `External` and use `charge-card` as the Topic.
+Open the Properties Panel within the Operaton Modeler and click on the Service Task you just created. Change the Implementation to `External` and use `charge-card` as the Topic.
 
 ![Example image](/img/get-started/quick-start/modeler-step4.png)
 

--- a/docs/get-started/quick-start/service-task.md
+++ b/docs/get-started/quick-start/service-task.md
@@ -7,7 +7,7 @@ description: 'Learn the basics of handling the Operaton Modeler, learn how to mo
 ---
 # Executing automated steps (2/6)
 
-In this section, you'll learn how to create your first BPMN 2.0 process with the Operaton Modeler and how to execute automated steps. Start by opening up Operaton Modeler.
+In this section, you'll learn how to create your first BPMN 2.0 process with the Operaton Modeler and how to execute automated steps. Start by opening Operaton Modeler.
 
 ## Create a new BPMN Diagram
 
@@ -85,7 +85,7 @@ In this section, you'll learn how to implement an external task worker in Java.
 
 Make sure you have the following tools installed:
 
-* JDK 11
+* JDK 17
 * An IDE for Java projects (e.g. [Eclipse](https://eclipse.org/))
 
 #### Create a new Maven project
@@ -105,7 +105,7 @@ When you're done, click Finish. Eclipse will set up a new Maven project. The pro
 #### Add Operaton External Task Client Dependency
 
 The next step consists of setting up the Maven dependency to the external task client for your new process application.
-Your pom.xml file of your project should look like this:
+Your project's `pom.xml` file should look like this:
 
 ```xml
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -118,8 +118,8 @@ Your pom.xml file of your project should look like this:
 
 	<properties>
 		<operaton.external-task-client.version>1.0.3</operaton.external-task-client.version>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 	</properties>
 
 	<dependencies>
@@ -197,7 +197,7 @@ public class ChargeCardWorker {
 
 #### Run the worker
 
-You can run the Java application by right clicking on the class `ChargeCardWorker` and choosing `Run as Java`.
+You can run the Java application by right-clicking the class `ChargeCardWorker` and choosing `Run as Java`.
 
 Note that the worker should remain running throughout the entirety of this quick start guide.
 

--- a/docs/get-started/quick-start/service-task.md
+++ b/docs/get-started/quick-start/service-task.md
@@ -38,7 +38,7 @@ Add an End Event named *Payment Received*.
 
 ### Configure the Service Task
 
-There are different ways to [execute service tasks](https://docs.operaton.org/docs/documentation/reference/bpmn20/tasks/service-task/) using Operaton Platform. In this guide, we'll use the external [task pattern](https://docs.operaton.org/docs/documentation/user-guide/process-engine/external-tasks/).
+There are different ways to [execute service tasks](/docs/documentation/reference/bpmn20/tasks/service-task/) using Operaton Platform. In this guide, we'll use the external [task pattern](/docs/documentation/user-guide/process-engine/external-tasks/).
 Open the Properties Panel within the Operaton Modeler and click on the Service Task you just created. Change the Implementation to `External` and use `charge-card` as the Topic.
 
 ![Example image](/img/get-started/quick-start/modeler-step4.png)
@@ -147,7 +147,7 @@ Your pom.xml file of your project should look like this:
 Next, we will create a new ExternalTaskClient which subscribes to the `charge-card` topic.
 
 When the process engine encounters a service task that is configured to be externally handled, it creates an external task instance on which our handler will react.
-We are using [Long Polling](https://docs.operaton.org/docs/documentation/user-guide/process-engine/external-tasks/#long-polling-to-fetch-and-lock-external-tasks) in the ExternalTaskClient to make the communication more efficient.
+We are using [Long Polling](/docs/documentation/user-guide/process-engine/external-tasks/#long-polling-to-fetch-and-lock-external-tasks) in the ExternalTaskClient to make the communication more efficient.
 
 Next, you need to create a package, e.g., *org.operaton.bpm.getstarted.chargecard* and add a Java class, e.g. *ChargeCardWorker*, to it.
 
@@ -251,7 +251,7 @@ npm install -D open
 Next, we'll create a new ExternalTaskClient that subscribes to the `charge-card` topic.
 
 When the process engine encounters a service task that's configured to be externally handled, it creates an external task instance on which our handler will react.
-We use [Long Polling](https://docs.operaton.org/docs/documentation/user-guide/process-engine/external-tasks/#long-polling-to-fetch-and-lock-external-tasks) in the ExternalTaskClient to make the communication more efficient.
+We use [Long Polling](/docs/documentation/user-guide/process-engine/external-tasks/#long-polling-to-fetch-and-lock-external-tasks) in the ExternalTaskClient to make the communication more efficient.
 
 Next, you need to create a new JavaScript file, e.g. `worker.js`, that looks like the following:
 

--- a/docs/get-started/quick-start/service-task.md
+++ b/docs/get-started/quick-start/service-task.md
@@ -182,7 +182,7 @@ public class ChargeCardWorker {
           LOGGER.info("Charging credit card with an amount of '" + amount + "'€ for the item '" + item + "'...");
 
           try {
-              Desktop.getDesktop().browse(new URI("https://docs.operaton.org/get-started/quick-start/complete"));
+              Desktop.getDesktop().browse(new URI("https://docs.operaton.org/docs/get-started/quick-start/user-task/"));
           } catch (Exception e) {
               e.printStackTrace();
           }
@@ -268,7 +268,7 @@ const config = { baseUrl: 'http://localhost:8080/engine-rest', use: logger, asyn
 // create a Client instance with custom configuration
 const client = new Client(config);
 
-// susbscribe to the topic: 'charge-card'
+// subscribe to the topic: 'charge-card'
 client.subscribe('charge-card', async function({ task, taskService }) {
   // Put your business logic here
 
@@ -276,9 +276,9 @@ client.subscribe('charge-card', async function({ task, taskService }) {
   const amount = task.variables.get('amount');
   const item = task.variables.get('item');
 
-  console.log(`Charging credit card with an amount of ```${amount}€ for the item '${item}'...`);
+  console.log(`Charging credit card with an amount of ${amount}€ for the item '${item}'...`);
 
-  open('https://docs.operaton.org/get-started/quick-start/success');
+  open('https://docs.operaton.org/docs/get-started/quick-start/user-task/');
 
   // Complete the task
   await taskService.complete(task);


### PR DESCRIPTION
## Summary
- remove the `Operaton Cloud` reference from the quick start deployment note
- align the quick start modeling and deployment instructions with Operaton Modeler instead of Camunda Modeler
- remove outdated Camunda Modeler blog links from the quick start deployment step
- preserve the old deployment heading anchor with a hidden id so existing links keep resolving
- use local documentation links for Quick Start references to the Operaton docs
- replace the quick start worker follow-up URLs that returned 404 with the existing next tutorial page and fix the JavaScript worker snippet
- align the quick start Java worker prerequisite and compiler settings with Java 17 and polish the updated Modeler/deployment instructions

## Verification
- `rg -n "JDK 11|maven\\.compiler\\.(source|target)>11|opening up Operaton Modeler|Your pom\\.xml file of your project|right clicking|POST Request|JSON Body|Move onto|larger or equal|process then|In order to retrieve|Decision Table, click on|Deployment Name|hit the Deploy|Process Instances|Process Instance will|Decision Instances" docs/get-started/quick-start/decision-automation.md docs/get-started/quick-start/deploy.md docs/get-started/quick-start/gateway.md docs/get-started/quick-start/service-task.md -S` returns no matches
- `rg -n "JDK 17|maven\\.compiler\\.(source|target)>17" docs/get-started/quick-start/service-task.md -S` confirms the Java worker now uses Java 17
- `rg -n "Camunda Modeler|Operaton Cloud|Camunda Cloud|blog\\.camunda|blog\\.operaton|camunda\\.com/download|downloads\\.camunda\\.cloud" docs/get-started/quick-start/index.md docs/get-started/quick-start/service-task.md docs/get-started/quick-start/user-task.md docs/get-started/quick-start/gateway.md docs/get-started/quick-start/decision-automation.md docs/get-started/quick-start/deploy.md -S` finds no matches
- `rg -n "use-the-camunda-modeler-to-deploy-the-process|Use the Operaton Modeler" docs/get-started/quick-start/deploy.md -S` confirms the compatibility anchor and new heading are present
- `rg -n "https://docs\\.operaton\\.org/docs/documentation" docs/get-started/quick-start/service-task.md docs/get-started/quick-start/gateway.md docs/get-started/quick-start/decision-automation.md -S` finds no matches
- `rg -n -e 'https://docs\\.operaton\\.org/get-started/quick-start/(complete|success)' -e 'docs\\.operaton\\.org/get-started/quick-start' -e 'susbscribe' -e 'amount of ```' docs/get-started/quick-start/service-task.md -S` finds no matches
- `curl -I -L --max-time 20 https://docs.operaton.org/docs/get-started/quick-start/user-task/` returns HTTP 200
- `git diff --check`
- `npm run typecheck`
- `npm run build` succeeds; it reports the known pre-existing Docusaurus link/anchor warnings that are handled separately in #115

