### PR TITLE
Fix CMMN extension namespace wording

### DIFF
--- a/docs/documentation/reference/cmmn11/custom-extensions/operaton-attributes.md
+++ b/docs/documentation/reference/cmmn11/custom-extensions/operaton-attributes.md
@@ -11,7 +11,7 @@ menu:
 
 ---
 
-The following attributes are extension attributes for the `camunda` namespace `http://operaton.org/schema/1.0/cmmn`.
+The following attributes are extension attributes for the `operaton` namespace `http://operaton.org/schema/1.0/cmmn`.
 
 ## assignee
 

--- a/docs/documentation/reference/cmmn11/custom-extensions/operaton-elements.md
+++ b/docs/documentation/reference/cmmn11/custom-extensions/operaton-elements.md
@@ -12,7 +12,7 @@ menu:
 ---
 
 
-The following elements are extension elements for the `camunda` namespace `http://operaton.org/schema/1.0/cmmn`.
+The following elements are extension elements for the `operaton` namespace `http://operaton.org/schema/1.0/cmmn`.
 
 ## caseExecutionListener
 


### PR DESCRIPTION
## Summary
- replace stale `camunda` namespace wording in the CMMN extension attribute reference
- replace stale `camunda` namespace wording in the CMMN extension element reference
- keep the documented namespace URI unchanged at `http://operaton.org/schema/1.0/cmmn`

## Verification
- `rg -n 'camunda` namespace|camunda namespace|`camunda` namespace' docs/documentation/reference/cmmn11/custom-extensions/operaton-attributes.md docs/documentation/reference/cmmn11/custom-extensions/operaton-elements.md -S` returned no matches
- `git diff --check`
- `npm run build` succeeds; it reports the known pre-existing `main` link/anchor warnings covered by separate docs quality work
