### PR TITLE
Fix DMN decision table namespace

### DIFF
--- a/docs/documentation/reference/dmn/decision-table/index.md
+++ b/docs/documentation/reference/dmn/decision-table/index.md
@@ -15,7 +15,7 @@ A decision table is represented by a `decisionTable` element inside a
 `decision` XML element.
 
 ```xml
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" id="definitions" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" id="definitions" name="definitions" namespace="http://operaton.org/schema/1.0/dmn">
   <decision id="dish" name="Dish">
     <decisionTable id="decisionTable">
     <!-- ... -->


### PR DESCRIPTION
## Summary
- replace the stale `http://camunda.org/schema/1.0/dmn` namespace in the decision table example
- align the example with the Operaton DMN namespace used by the surrounding reference docs
- restore the missing final newline in the touched Markdown file

## Verification
- `rg -n "http://camunda.org/schema/1.0/dmn|http://camunda.org/schema/1.0" docs/documentation/reference/dmn docs/documentation/user-guide/dmn-engine docs/get-started/dmn -S` returned no matches
- `git diff --check`
- `npm run build` succeeds; it reports the known pre-existing `main` link/anchor warnings covered by separate docs quality work
