### PR TITLE
Remove stale license book exclude

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -54,8 +54,7 @@ const config: Config = {
         docs: {
           sidebarPath: './sidebars.ts',
           exclude: [
-            '**/_*.{js,jsx,ts,tsx,md,mdx,bpmn}',
-            'docs/documentation/introduction/third-party-libraries/camunda-bpm-platform-license-book.md'
+            '**/_*.{js,jsx,ts,tsx,md,mdx,bpmn}'
           ],
 
           // The BPMN remark plugin


### PR DESCRIPTION
## Summary
- remove the Docusaurus docs exclude for the old `camunda-bpm-platform-license-book.md` file
- leave the real underscore-file exclude pattern in place

## Verification
- `git ls-tree -r origin/main --name-only | rg "camunda-bpm-platform-license-book|third-party-libraries"` shows only the current third-party libraries index page, not the excluded file
- `rg -n "camunda-bpm-platform-license-book|Camunda BPM Platform License Book" docusaurus.config.ts docs src README.md -S` returned no matches
- `git diff --check`
- `npm run build` succeeds; it reports the known pre-existing Docusaurus link/anchor warnings
