### PR TITLE
Align task metrics wording with Operaton

### DIFF
--- a/docs/documentation/user-guide/process-engine/database/database-schema.md
+++ b/docs/documentation/user-guide/process-engine/database/database-schema.md
@@ -87,7 +87,7 @@ The default configuration of the [MetricsReporter](../../process-engine/metrics.
 ## Task Metrics Log (ACT_RU_TASK_METER_LOG)
 
 The `ACT_RU_TASK_METER_LOG` table contains a collection of task related metrics that can help draw conclusions about usage, load
-and performance of the BPM platform. Task metrics contain a pseudonymized and fixed-length value of task assignees and their time of appearance. Please find detailed information about how task metrics are collected in the [Metrics User Guide](../../process-engine/metrics.md).
+and performance of Operaton. Task metrics contain a pseudonymized and fixed-length value of task assignees and their time of appearance. Please find detailed information about how task metrics are collected in the [Metrics User Guide](../../process-engine/metrics.md).
 
 Every assignment of a task to an assignee will create one row in `ACT_RU_TASK_METER_LOG`.
 

--- a/docs/documentation/user-guide/process-engine/history/history-cleanup.md
+++ b/docs/documentation/user-guide/process-engine/history/history-cleanup.md
@@ -233,7 +233,7 @@ history cleanup jobs. The property accepts values in the ISO-8601 date format. N
 
 #### Task metrics
 
-The process engine reports [runtime metrics](../../process-engine/metrics.md) to the database that can help draw conclusions about usage, load, and performance of the BPM platform.
+The process engine reports [runtime metrics](../../process-engine/metrics.md) to the database that can help draw conclusions about usage, load, and performance of Operaton.
 With every assignment of a user task, the related task worker is stored as a pseudonymized, fixed-length value in the `ACT_RU_TASK_METER_LOG` table together with a timestamp. Cleanup for this data needs to
 be configured explicitly if needed.
 


### PR DESCRIPTION
## Summary
- replace generic `BPM platform` wording in task metrics sections with `Operaton`
- align the task metrics wording with the existing runtime metrics wording nearby
- restore missing final newlines in the touched markdown files

## Verification
- `rg -n "performance of the BPM platform|BPM platform" docs/documentation/user-guide/process-engine docs/documentation/reference/release-notes -S` now only reports the historical release-note reference to the former open-source BPM platform
- `git diff --check`
- `npm run build` succeeds; it reports the known pre-existing Docusaurus link/anchor warnings
