### PR TITLE
Fix JSF task form caption typo

### DIFF
--- a/docs/documentation/user-guide/task-forms/jsf-task-forms.md
+++ b/docs/documentation/user-guide/task-forms/jsf-task-forms.md
@@ -151,7 +151,7 @@ In the forms you can access your own CDI beans as usual and also access the Oper
 
 This is rendered to a simple form:
 
-![Example img](/img/documentation/user-guide/task-forms/variablesTaskFormExample.png)Varibales Task Form Example
+![Example img](/img/documentation/user-guide/task-forms/variablesTaskFormExample.png)Variables Task Form Example
 
 The same mechanism can be used to start a new process instance:
 


### PR DESCRIPTION
## Summary
- fix the `Varibales Task Form Example` image caption typo in the JSF task forms guide

## Verification
- `rg -n "Varibales|Variables Task Form Example" docs/documentation/user-guide/task-forms/jsf-task-forms.md -S` reports only the corrected caption
- `git diff --check`
- `npm run build` succeeds; it reports the known pre-existing Docusaurus link/anchor warnings
