### PR TITLE
Fix JavaScript capitalization in docs

### DIFF
--- a/docs/documentation/reference/forms/embedded-forms/javascript/generating-businesskey.md
+++ b/docs/documentation/reference/forms/embedded-forms/javascript/generating-businesskey.md
@@ -10,7 +10,7 @@ menu:
 
 ---
 
-The following example shows how you can generate a business key using Javascript:
+The following example shows how you can generate a business key using JavaScript:
 
 ```html
 <form role="form">

--- a/docs/documentation/reference/spin/json/01-reading-json.md
+++ b/docs/documentation/reference/spin/json/01-reading-json.md
@@ -60,7 +60,7 @@ SpinJsonNode json = JSON(reader);
 
 ## Reading JSON using a Script Language
 
-JSON can be read from script languages in the same way as from Java. Since script languages use dynamic typing, you do not need to hint the data format but you can use autodetection. The following example demonstrates how to read JSON in Javascript:
+JSON can be read from script languages in the same way as from Java. Since script languages use dynamic typing, you do not need to hint the data format but you can use autodetection. The following example demonstrates how to read JSON in JavaScript:
 
 ```javascript
 var customer = S('{"customer": "Kermit"}');
@@ -81,7 +81,7 @@ SpinJsonNode customerProperty = json.prop("customer");
 String customerName = customerProperty.stringValue();
 ```
 
-in Javascript:
+in JavaScript:
 
 ```javascript
 var json = S('{"customer": "Kermit"}');
@@ -131,7 +131,7 @@ SpinJsonNode customer = customers.get(0);
 String customerName = customer.stringValue();
 ```
 
-in Javascript:
+in JavaScript:
 
 ```javascript
 var json = S('{"customer": ["Kermit", "Waldo"]}');
@@ -143,7 +143,7 @@ var customerName = customer.value();
 
 ### Fetch Field Names
 
-Spin allows us to use the `.fieldNames()` method to fetch the names of all child nodes and properties in a node. The following example shows you how to use `.fieldNames()` in Java and Javascript.
+Spin allows us to use the `.fieldNames()` method to fetch the names of all child nodes and properties in a node. The following example shows you how to use `.fieldNames()` in Java and JavaScript.
 
 in Java:
 
@@ -155,7 +155,7 @@ ArrayList fieldNames = json.fieldNames();
 String fieldName1 = fieldNames.get(0)
 ```
 
-in Javascript:
+in JavaScript:
 
 ```javascript
 var json = S('{"customer": ["Kermit", "Waldo"]}');
@@ -190,7 +190,7 @@ or one of the 2 following container types:
     json.prop("new_array", list);
     ```
 
-    Example in Javascript:
+    Example in JavaScript:
 
     ```javascript
     var json = S('{"customer": ["Kermit", "Waldo"]}');
@@ -212,7 +212,7 @@ or one of the 2 following container types:
     json.prop("new_object", object);
     ```
 
-    Example in Javascript:
+    Example in JavaScript:
 
     ```javascript
     var json = S('{"customer": ["Kermit", "Waldo"]}');
@@ -231,7 +231,7 @@ There are 2 ways to remove properties from a JSON object.
   * `.deleteProp("name")` - Removes a property with given name.
   * `.deleteProp(<List of names>)` - Removes one or more properties with given names.
 
-For more details see the following examples for Javascript and Java.
+For more details see the following examples for JavaScript and Java.
 
 Java:
 
@@ -250,7 +250,7 @@ json.deleteProp("customer");
 json.deleteProp(list);
 ```
 
-Javascript:
+JavaScript:
 
 ```javascript
 var json = S('{"customer": ["Kermit", "Waldo"], "language": "en"}');

--- a/docs/documentation/user-guide/dmn-engine/expressions-and-scripts.md
+++ b/docs/documentation/user-guide/dmn-engine/expressions-and-scripts.md
@@ -74,8 +74,8 @@ The Operaton DMN engine supports two expression languages out of the box:
 - `JUEL`: A Operaton-maintained [implementation][juel] of the Java [Unified Expression Language][EL]
 - `FEEL`: The Friendly Enough Expression Language of the [DMN 1.2] standard.
 
-Depending on the JDK you use, there may also be a `Javascript` implementation
-available like [Rhino] or [Nashhorn].
+Depending on the JDK you use, there may also be a `JavaScript` implementation
+available like [Rhino] or [Nashorn].
 
 You can also use every other script language which provides a [JSR-223]
 implementation. This includes `groovy`, `python` and `ruby`. To use these
@@ -207,7 +207,7 @@ the script engine before using it.
 [EL]: https://jakarta.ee/specifications/expression-language/4.0/
 [DMN 1.2]: http://www.omg.org/spec/DMN/
 [Rhino]: https://developer.mozilla.org/de/docs/Rhino
-[Nashhorn]: https://blogs.oracle.com/nashorn/
+[Nashorn]: https://blogs.oracle.com/nashorn/
 [JSR-223]: https://www.jcp.org/en/jsr/detail?id=223
 [default EL]: ../../user-guide/dmn-engine/embed.md#change-default-expression-languages
 [configure EL]: ../../user-guide/dmn-engine/embed.md#customize-expression-and-script-resolving

--- a/docs/documentation/webapps/admin/plugins.md
+++ b/docs/documentation/webapps/admin/plugins.md
@@ -34,7 +34,7 @@ Here you can see the various points at which you are able to add your own plugin
 
 This plugin points properties contain the attribute `path`, which stands for the hashRoute for this page. This will be rendered when the user navigates in the browser to the url, e.g. `#/my-path`.
 
-```Javascript
+```javascript
 properties: {
   path: "/my-path"
 }
@@ -50,7 +50,7 @@ With Operaton.5, the Admin webapp gets a dashboard based on plugins similar to t
 
 This plugin points properties contain the attributes `label` and `pagePath`, which are the heading of the new Section as well as the linked sub-page of the heading. If `pagePath` is `undefined`, the label will not be rendered as a link.
 
-```Javascript
+```javascript
 properties: {
   label: "My Plugin",
   pagePath: '#/myPage'

--- a/docs/documentation/webapps/tasklist/tasklist-plugins.md
+++ b/docs/documentation/webapps/tasklist/tasklist-plugins.md
@@ -52,7 +52,7 @@ Here you can see the various points at which you are able to add your own plugin
 
 This plugin points properties contain the attribute `label`, which will be rendered in the navigation even when the plugin is not selected.
 
-```Javascript
+```javascript
 properties: {
   label: "My Plugin"
 }


### PR DESCRIPTION
## Summary
- standardize JavaScript capitalization in selected docs prose
- change JavaScript code fences from `Javascript` to `javascript`
- fix the Nashorn script engine reference label typo

## Verification
- `rg -n '\\bJavascript\\b|\\bNashhorn\\b|```Javascript' docs/documentation/reference/forms/embedded-forms/javascript/generating-businesskey.md docs/documentation/reference/spin/json/01-reading-json.md docs/documentation/user-guide/dmn-engine/expressions-and-scripts.md docs/documentation/webapps/admin/plugins.md docs/documentation/webapps/tasklist/tasklist-plugins.md -S` returned no matches\n- `git diff --check`\n- checked changed files against open PR file lists; no overlaps\n- `npm run build` succeeds; it reports the known pre-existing Docusaurus link/anchor warnings\n