### PR TITLE
Fix WildFly capitalization in shared webapp docs

### DIFF
--- a/docs/documentation/webapps/shared-options/authentication.md
+++ b/docs/documentation/webapps/shared-options/authentication.md
@@ -81,7 +81,7 @@ This is what the `web.xml`-based configuration looks like:
 
 ## Container-Based Authentication
 
-Operaton supports a broad range of containers, including Tomcat, Wildfly, IBM WebSphere and Oracle WebLogic. Using Container-Based Authentication, it is possible to move the authentication action to the container level, which will then make the authentication result available to the Operaton Web Applications.
+Operaton supports a broad range of containers, including Tomcat, WildFly, IBM WebSphere and Oracle WebLogic. Using Container-Based Authentication, it is possible to move the authentication action to the container level, which will then make the authentication result available to the Operaton Web Applications.
 
 :::note[Heads-up!]
 Please provide an implementation for the `ReadOnlyIdentityProvider` interface so that queries return the results of your identity provider to make **Container-Based Authentication** work.

--- a/docs/documentation/webapps/shared-options/cookie-security.md
+++ b/docs/documentation/webapps/shared-options/cookie-security.md
@@ -117,7 +117,7 @@ This section describes how to configure the **Session Cookie** as well as the **
 Here you can find how to configure the session cookie for the following containers:
 
 * [Tomcat](../../installation/full/tomcat/configuration.md#session-cookie-in-webapps)
-* [Wildfly](../../installation/full/wildfly/configuration.md#session-cookie-in-webapps)
+* [WildFly](../../installation/full/wildfly/configuration.md#session-cookie-in-webapps)
 * [Spring Boot](../../user-guide/spring-boot-integration/configuration.mdx#session-cookie)
 
 ### CSRF Cookie

--- a/docs/documentation/webapps/shared-options/header-security.md
+++ b/docs/documentation/webapps/shared-options/header-security.md
@@ -158,7 +158,7 @@ the config property <code>hstsValue</code>.
 Choose a container from the list and learn where to configure the HTTP Security Headers:
 
 * [Tomcat](../../installation/full/tomcat/configuration.md#security-related-http-headers-in-webapps)
-* [Wildfly](../../installation/full/wildfly/configuration.md#security-related-http-headers-in-webapps)
+* [WildFly](../../installation/full/wildfly/configuration.md#security-related-http-headers-in-webapps)
 * [Spring Boot](../../user-guide/spring-boot-integration/configuration.mdx)
 
 ## How to Configure?


### PR DESCRIPTION
## Summary
- update shared webapp option docs to use the official WildFly capitalization
- keep the existing lowercase `wildfly` URL paths unchanged
- add the missing final newline in `cookie-security.md`

## Verification
- `rg -n '\\bWildfly\\b' docs/documentation/webapps/shared-options/authentication.md docs/documentation/webapps/shared-options/cookie-security.md docs/documentation/webapps/shared-options/header-security.md -S` returned no matches\n- `git diff --check`\n- checked changed files against open PR file lists; no overlaps\n- `npm run build` succeeds; it reports the known pre-existing Docusaurus link/anchor warnings\n