### PR TITLE
Fix WildFly distribution asset name

### DIFF
--- a/docs/documentation/installation/full/tomcat/pre-packaged.md
+++ b/docs/documentation/installation/full/tomcat/pre-packaged.md
@@ -12,6 +12,7 @@ description: "Download and install Apache Tomcat with the Full Distribution pre-
 1.  Download the pre-packaged distribution from "Assets" of https://github.com/operaton/operaton/releases/latest
   - Operaton Standalone distribution: `operaton-bpm-<version>.tar.gz` (or `.zip`)
   - Operaton Tomcat distribution: `operaton-bpm-tomcat-<version>.tar.gz` (or `.zip`)
+  - Operaton Wildfly distribution: `operaton-bpm-wildfly-<version>.tar.gz` (or `.zip`)
 3.  Unpack the distro to a directory.
 4.  Adjust the datasource according to your needs (see [Manual Installation](manual.md)).
 5.  Startup the server by running the `start.sh` script.

--- a/docs/documentation/installation/full/tomcat/pre-packaged.md
+++ b/docs/documentation/installation/full/tomcat/pre-packaged.md
@@ -12,7 +12,6 @@ description: "Download and install Apache Tomcat with the Full Distribution pre-
 1.  Download the pre-packaged distribution from "Assets" of https://github.com/operaton/operaton/releases/latest
   - Operaton Standalone distribution: `operaton-bpm-<version>.tar.gz` (or `.zip`)
   - Operaton Tomcat distribution: `operaton-bpm-tomcat-<version>.tar.gz` (or `.zip`)
-  - Operaton Wildfly distribution: `operaton-bpm-tomcat-<version>.tar.gz` (or `.zip`)
 3.  Unpack the distro to a directory.
 4.  Adjust the datasource according to your needs (see [Manual Installation](manual.md)).
 5.  Startup the server by running the `start.sh` script.


### PR DESCRIPTION
## Summary
- remove the duplicate Tomcat artifact entry that was labeled as a Wildfly distribution on the Tomcat pre-packaged installation page

## Verification
- `rg -n "Operaton Wildfly distribution|Operaton WildFly distribution|operaton-bpm-tomcat" docs/documentation/installation/full/tomcat/pre-packaged.md -S` now shows only the correct Tomcat distribution entry
- `git diff --check`
- checked changed files against open PR file lists; no overlaps
- `npm run build` succeeds; it reports the known pre-existing Docusaurus link/anchor warnings
