### PR TITLE
Fix installation page wording

### DIFF
--- a/docs/documentation/installation/full/index.md
+++ b/docs/documentation/installation/full/index.md
@@ -2,7 +2,7 @@
 
 title: "Shared Engine Distribution"
 sidebar_position: 10
-description: "Install the Shared Process Engine and Web Applications inside an Application Server like Wildfly or Tomcat."
+description: "Install the Shared Process Engine and Web Applications inside an application server like WildFly or Tomcat."
 
 ---
 # Install the Shared Engine Distribution

--- a/docs/documentation/installation/standalone-webapplication.md
+++ b/docs/documentation/installation/standalone-webapplication.md
@@ -1,11 +1,11 @@
 ---
 
-title: "Standalone Webapplication (.war)"
+title: "Standalone Web Application (.war)"
 sidebar_position: 20
-description: "Install the Standalone Webapplication (bundling an embedded Process Engine) inside an Application Server like Wildfly or Tomcat."
+description: "Install the Standalone Web Application (bundling an embedded Process Engine) inside an application server like WildFly or Tomcat."
 
 ---
-## Install the Standalone Webapplication (.war)
+## Install the Standalone Web Application (.war)
 
 Operaton Automation 7.19 is the last release providing support for Standalone Web Application Distribution.
 


### PR DESCRIPTION
## Summary
- update standalone web application page title, description, and heading from `Webapplication` to `Web Application`
- use the official WildFly capitalization in installation page descriptions
- normalize `Application Server` to `application server` in prose descriptions

## Verification
- `rg -n '\\bWebapplication\\b|\\bWildfly\\b|Application Server like' docs/documentation/installation/standalone-webapplication.md docs/documentation/installation/full/index.md -S` returned no matches\n- `git diff --check`\n- checked changed files against open PR file lists; no overlaps\n- `npm run build` succeeds; it reports the known pre-existing Docusaurus link/anchor warnings\n