### PR TITLE
Fix REST API capitalization in architecture docs

### DIFF
--- a/docs/documentation/introduction/architecture.md
+++ b/docs/documentation/introduction/architecture.md
@@ -99,7 +99,7 @@ The Operaton web applications are based on a RESTful architecture.
 
 Frameworks used:
 
-* [JAX-RS](https://jax-rs-spec.java.net) based Rest API
+* [JAX-RS](https://jax-rs-spec.java.net) based REST API
 * [AngularJS](http://angularjs.org)
 * [RequireJS](http://requirejs.org)
 * [jQuery](http://jquery.com)


### PR DESCRIPTION
## Summary
- update the architecture page to spell `REST API` with the standard capitalization

## Verification
- `rg -n '\\bRest API\\b|\\bREST Api\\b' docs/documentation/introduction/architecture.md -S` returned no matches\n- `git diff --check`\n- checked changed files against open PR file lists; no overlaps\n- `npm run build` succeeds; it reports the known pre-existing Docusaurus link/anchor warnings\n