### PR TITLE
Fix GitHub capitalization in docs

### DIFF
--- a/docs/documentation/examples/index.md
+++ b/docs/documentation/examples/index.md
@@ -9,4 +9,4 @@ Completed the [Getting Started Guides](../../get-started/index.md)? Now discover
 
 This page collects links to hands-on examples around Operaton.
 
-* [Examples](https://github.com/operaton/operaton-bpm-examples) (On Github)
+* [Examples](https://github.com/operaton/operaton-bpm-examples) (on GitHub)

--- a/docs/documentation/reference/forms/embedded-forms/integrate/full-examples.md
+++ b/docs/documentation/reference/forms/embedded-forms/integrate/full-examples.md
@@ -10,7 +10,7 @@ menu:
 
 ---
 
-Full examples of how to integrate the Forms SDK in a custom application can be found in the [Operaton Examples Repository](https://github.com/operaton/operaton-bpm-examples) in Github.
+Full examples of how to integrate the Forms SDK in a custom application can be found in the [Operaton Examples Repository](https://github.com/operaton/operaton-bpm-examples) on GitHub.
 
 * [Example for standalone usage of the SDK](https://github.com/operaton/operaton-bpm-examples/tree/master/sdk-js/browser-forms)
 * [Example for standalone usage of the SDK with AngularJS Integration](https://github.com/operaton/operaton-bpm-examples/tree/master/sdk-js/browser-forms-angular)

--- a/docs/documentation/reference/forms/embedded-forms/integrate/getting-a-distribution.md
+++ b/docs/documentation/reference/forms/embedded-forms/integrate/getting-a-distribution.md
@@ -13,7 +13,7 @@ menu:
 # Manual Download
 
 The Forms SDK library can be downloaded from
-[Github](https://github.com/operaton/bower-operaton-bpm-sdk-js/releases).
+[GitHub](https://github.com/operaton/bower-operaton-bpm-sdk-js/releases).
 
 
 # Bower


### PR DESCRIPTION
## Summary
- update GitHub brand capitalization in examples and embedded forms integration docs
- adjust surrounding prepositions/capitalization for natural prose

## Verification
- `rg -n '\\bGithub\\b' docs/documentation/examples/index.md docs/documentation/reference/forms/embedded-forms/integrate/getting-a-distribution.md docs/documentation/reference/forms/embedded-forms/integrate/full-examples.md -S` returned no matches\n- `git diff --check`\n- checked changed files against open PR file lists; no overlaps\n- `npm run build` succeeds; it reports the known pre-existing Docusaurus link/anchor warnings\n