### PR TITLE
Fix WildFly spelling in release notes

### DIFF
--- a/docs/documentation/reference/release-notes/1_0/index.md
+++ b/docs/documentation/reference/release-notes/1_0/index.md
@@ -78,7 +78,7 @@ The Operaton Quarkus extension is based on **Quarkus 3.28.3**.
 
 The Tomcat distribution is based on **Tomcat 11.0.12**.
 
-The Wildfly distribution is based on **Wildfly 37.0.1**.
+The WildFly distribution is based on **WildFly 37.0.1**.
 
 ### Standards Compliance
 

--- a/docs/documentation/reference/release-notes/1_1/index.md
+++ b/docs/documentation/reference/release-notes/1_1/index.md
@@ -19,7 +19,7 @@ With this release we focused on:
 ### Distribution specific SBOMs & License Book
 
 With this release we are providing distribution specific SBOMs (Software Bill of Materials) and License Book document
-for the 3 distributions (Tomcat, Wildfly, and Spring Boot).
+for the 3 distributions (Tomcat, WildFly, and Spring Boot).
 
 With 1.0, Operaton provided a single SBOM and License Book document for all distributions, 
 which was not ideal as the distributions have different dependencies.
@@ -75,7 +75,7 @@ The Operaton Quarkus extension is based on **Quarkus 3.30.8**.
 
 The Tomcat distribution is based on **Tomcat 11.0.18**.
 
-The Wildfly distribution is based on **Wildfly 38.0.1**.
+The WildFly distribution is based on **WildFly 38.0.1**.
 
 ### Standards Compliance
 

--- a/docs/documentation/reference/release-notes/2_0/index.md
+++ b/docs/documentation/reference/release-notes/2_0/index.md
@@ -136,7 +136,7 @@ The Operaton Quarkus extension is based on **Quarkus 3.30**.
 
 The Tomcat distribution is based on **Tomcat 11**.
 
-The Wildfly distribution is based on **Wildfly 38**.
+The WildFly distribution is based on **WildFly 38**.
 
 ### Standards Compliance
 

--- a/docs/documentation/reference/release-notes/2_1/index.md
+++ b/docs/documentation/reference/release-notes/2_1/index.md
@@ -368,7 +368,7 @@ The Operaton Quarkus extension is based on **Quarkus 3.33.1 LTS**.
 
 The Tomcat distribution is based on **Tomcat 11.0.21**.
 
-The Wildfly distribution is based on **Wildfly 38.0.1**.
+The WildFly distribution is based on **WildFly 38.0.1**.
 
 ### Database Compatibility
 


### PR DESCRIPTION
## Summary
- update visible WildFly product spelling across release notes
- keep Camunda Community Edition migration wording unchanged because it refers to the source project

## Verification
- rg -n '\\bWildfly\\b' docs/documentation/reference/release-notes/1_0/index.md docs/documentation/reference/release-notes/1_1/index.md docs/documentation/reference/release-notes/2_0/index.md docs/documentation/reference/release-notes/2_1/index.md -S\n- git diff --check\n- npm run build (passes with existing Docusaurus broken-link and broken-anchor warnings)