### PR TITLE
Remove stale Camunda Jira reference from Quarkus CDI docs

### DIFF
--- a/docs/documentation/user-guide/quarkus-integration/cdi-integration.md
+++ b/docs/documentation/user-guide/quarkus-integration/cdi-integration.md
@@ -113,8 +113,7 @@ when trying to persist the beans as process variables.
 
 #### Destroying Bean Instances is unsupported
 
-Programmatically destroying a `@BusinessProcessScoped` bean instance is
-[currently unsupported][destroy-jira-issue].
+Programmatically destroying a `@BusinessProcessScoped` bean instance is currently unsupported.
 
 The following API methods will throw an `UnsupportedOperationException`:
 
@@ -144,6 +143,5 @@ You can learn about the available beans and programming model in the [CDI and Ja
 [arc-config-reference]: https://quarkus.io/guides/cdi-reference#quarkus-arc_quarkus.arc.auto-inject-fields
 [business-process-scoped]: ../cdi-java-ee-integration/contextual-programming-model.md#work-with-businessprocessscoped-beans
 [cdi-passivation]: https://jakarta.ee/specifications/cdi/4.0/jakarta-cdi-spec-4.0.html#passivating_scope
-[destroy-jira-issue]: https://jira.camunda.com/browse/CAM-13755
 [jsf-task-forms]: ../task-forms/jsf-task-forms.md
 [quarkus-bean-scopes]: https://quarkus.io/guides/cdi#bean-scope-available


### PR DESCRIPTION
## Summary
- remove the old Camunda Jira link from the Quarkus CDI limitation docs
- keep the unsupported bean-destroy behavior documented directly without linking to a deprecated external tracker

## Verification
- npm run build
- rg -n 'jira\.camunda\.com|CAM-13755|destroy-jira-issue' docs/documentation/user-guide/quarkus-integration/cdi-integration.md -S