### PR TITLE
Update get started docs for Operaton Modeler

### DIFF
--- a/docs/documentation/installation/camunda-modeler.md
+++ b/docs/documentation/installation/camunda-modeler.md
@@ -1,10 +1,10 @@
 ---
 
-title: "Camunda Modeler"
+title: "Operaton Modeler"
 sidebar_position: 01
-description: "Install the Camunda Modeler for BPMN 2.0, DMN 1.3 and Operaton Forms"
+description: "Install the Operaton Modeler for BPMN 2.0, DMN 1.3 and Operaton Forms"
 
 ---
-# Install the Camunda Modeler
+# Install the Operaton Modeler
 
-You can find out how to install the Camunda Desktop Modeler on the Camunda [documentation website](https://docs.camunda.io/docs/components/modeler/camunda-modeler/install-the-modeler/).
+You can find the Operaton Modeler and its installation instructions in the [Operaton Modeler repository](https://github.com/operaton/operaton-modeler).

--- a/docs/documentation/introduction/index.md
+++ b/docs/documentation/introduction/index.md
@@ -29,7 +29,7 @@ To give you an overview of Operaton, the following illustration shows the most i
 
 ## Modeler
 
-* [Camunda Modeler](../modeling-bpmn/index.md): Modeling tool for BPMN 2.0 and CMMN 1.1 diagrams as well as DMN 1.3 decision tables.
+* [Operaton Modeler](../modeling-bpmn/index.md): Modeling tool for BPMN 2.0 and CMMN 1.1 diagrams as well as DMN 1.3 decision tables.
 * [bpmn.io](http://bpmn.io/): Open-source project for the modeling framework and toolkits.
 
 ## Web Applications

--- a/docs/documentation/modeling-bpmn/index.md
+++ b/docs/documentation/modeling-bpmn/index.md
@@ -7,4 +7,4 @@ sidebar_position: 45
 
 You can continue to model your process models with the Desktop Modeler from Camunda. The processes from this can be imported and processed by Operaton.
 
-You can find the Camunda Modeler documentation [here](https://docs.camunda.io/docs/components/modeler/about-modeler/).
+You can find the Operaton Modeler and its documentation in the [Operaton Modeler repository](https://github.com/operaton/operaton-modeler).

--- a/docs/get-started/archive/java-process-app/index.md
+++ b/docs/get-started/archive/java-process-app/index.md
@@ -2,7 +2,7 @@
 
 title: 'Java Process Application'
 sidebar_position: 3
-description: "Learn how to model a BPMN 2.0 process using the Camunda Modeler, add a Java Class and HTML Forms. Package it as a web application and deploy it to an Apache Tomcat Server."
+description: "Learn how to model a BPMN 2.0 process using the Operaton Modeler, add a Java Class and HTML Forms. Package it as a web application and deploy it to an Apache Tomcat Server."
 
 ---
 # Get started with Operaton and BPMN 2.0

--- a/docs/get-started/archive/java-process-app/model.md
+++ b/docs/get-started/archive/java-process-app/model.md
@@ -8,11 +8,11 @@ menu:
     name: "Model a Process"
     parent: "get-started-pa"
     identifier: "get-started-pa-model"
-    description: "Learn the basics of handling the Camunda Modeler and learn how to model and configure a fully executable process."
+    description: "Learn the basics of handling the Operaton Modeler and learn how to model and configure a fully executable process."
 
 ---
 
-In this section you learn how to create your first BPMN 2.0 process with the Camunda Modeler. Start up the Camunda Modeler now.
+In this section you learn how to create your first BPMN 2.0 process with the Operaton Modeler. Start up the Operaton Modeler now.
 
 ## Create a new BPMN Diagram
 

--- a/docs/get-started/archive/javaee7/model.md
+++ b/docs/get-started/archive/javaee7/model.md
@@ -8,18 +8,18 @@ menu:
     name: "Model a Process"
     parent: "get-started-java-ee"
     identifier: "get-started-java-ee-model"
-    description: "Learn the basics of handling the Camunda Modeler and learn how to model and configure a fully executable process."
+    description: "Learn the basics of handling the Operaton Modeler and learn how to model and configure a fully executable process."
 
 ---
 
-In this section we model our sample process with the Camunda Modeler.
+In this section we model our sample process with the Operaton Modeler.
 
 
 ## Create a new BPMN 2.0 Diagram
 
 ![Example image](/img/get-started/archive/javaee7/modeler-new-bpmn-diagram.png)
 
-Open Camunda Modeler and create a new BPMN diagram by Clicking *File > New File > BPMN Diagram*.
+Open Operaton Modeler and create a new BPMN diagram by clicking *File > New File > BPMN Diagram*.
 
 ### Create the Sample Pizza Order Process
 

--- a/docs/get-started/archive/javaee7/start-form.md
+++ b/docs/get-started/archive/javaee7/start-form.md
@@ -85,7 +85,7 @@ When the form is submitted, the `camundaTaskForm.completeProcessInstanceForm()` 
 
 ![Example image](/img/get-started/archive/javaee7/pizza-order-process-start-form.png)
 
-Open the process with Camunda Modeler. Click on the start event. In the properties view, set the `Form Key` property to `app:placeorder.jsf`. This means that we want to use an external JSF form and that the form is loaded from the application.
+Open the process with Operaton Modeler. Click on the start event. In the properties view, set the `Form Key` property to `app:placeorder.jsf`. This means that we want to use an external JSF form and that the form is loaded from the application.
 
 When you are done, save all resources, refresh the Eclipse project, perform a Maven build, and redeploy the process application.
 
@@ -94,4 +94,3 @@ It is best practice to perform a `clean install` build to make sure all resource
 :::
 
 If you open the Tasklist and start a new process instance for the pizza order process, the JSF form is displayed.
-

--- a/docs/get-started/archive/spring/index.md
+++ b/docs/get-started/archive/spring/index.md
@@ -9,7 +9,7 @@ description: "Get started with using Operaton Platform in a Spring Web Applicati
 This tutorial guides you through your first steps of using Operaton Platform in a Spring web application.
 
 **Target Audience**:
-In this tutorial we assume that you are familiar with the basics of Java web application development and the Spring Framework. We also assume that you have installed an Eclipse distribution and the Camunda Modeler.
+In this tutorial we assume that you are familiar with the basics of Java web application development and the Spring Framework. We also assume that you have installed an Eclipse distribution and the Operaton Modeler.
 
 
 You will be guided through the following steps:

--- a/docs/get-started/archive/spring/service-task.md
+++ b/docs/get-started/archive/spring/service-task.md
@@ -27,7 +27,7 @@ model and interact with the process form inside our Spring beans. In this sectio
 
 ### Model an Executable BPMN 2.0 Process
 
-Start by modeling an executable process using the Camunda Modeler. The process should look as depicted in the screenshot below.
+Start by modeling an executable process using the Operaton Modeler. The process should look as depicted in the screenshot below.
 
 ![Example image](/img/get-started/archive/spring/process-model.png)
 
@@ -110,7 +110,7 @@ public class LoanApplicationContext {
 
 ![Example image](/img/get-started/archive/spring/service-task.png)
 
-Referencing a Spring Bean from a BPMN 2.0 Service Task is simple. As shown in the screenshot above, we have to select the service task in the Camunda Modeler and provide an expression. Set *Implementation Type* to *Delegate Expression* and type `${calculateInterestService}` in the *Delegate Expression* field. Again, save the model and refresh the Eclipse project.
+Referencing a Spring Bean from a BPMN 2.0 Service Task is simple. As shown in the screenshot above, we have to select the service task in the Operaton Modeler and provide an expression. Set *Implementation Type* to *Delegate Expression* and type `${calculateInterestService}` in the *Delegate Expression* field. Again, save the model and refresh the Eclipse project.
 
 Finally, we add the Java class implementing the `JavaDelegate` interface.
 

--- a/docs/get-started/dmn/index.md
+++ b/docs/get-started/dmn/index.md
@@ -2,7 +2,7 @@
 
 title: 'DMN'
 sidebar_position: 3
-description: "Learn how to create a DMN 1.3 decision table using the Camunda Modeler. Package it as a web application and deploy it to an Apache Tomcat Server."
+description: "Learn how to create a DMN 1.3 decision table using the Operaton Modeler. Package it as a web application and deploy it to an Apache Tomcat Server."
 
 ---
 

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -7,7 +7,7 @@ There are different ways to get started with Operaton. Choose from the following
 
 ## [Quick Start (Java / JS)](./quick-start/index.md)
 
-Learn how to model a BPMN 2.0 process using the Camunda Modeler, adding a Java or JavaScript Worker. Deploy it to the Operaton Platform.
+Learn how to model a BPMN 2.0 process using the Operaton Modeler, adding a Java or JavaScript Worker. Deploy it to the Operaton Platform.
 
 ## [Spring Boot](./spring-boot/index.md)
 
@@ -15,7 +15,7 @@ Get started with using Operaton Platform in Spring Boot application.
 
 ## [DMN](./dmn/index.md)
 
-Learn how to create a DMN 1.3 decision table using the Camunda Modeler. Package it as a web application and deploy it to an Apache Tomcat Server.
+Learn how to create a DMN 1.3 decision table using the Operaton Modeler. Package it as a web application and deploy it to an Apache Tomcat Server.
 
 ## [Archive](./archive/index.md)
 Archived guides

--- a/docs/get-started/quick-start/gateway.md
+++ b/docs/get-started/quick-start/gateway.md
@@ -13,7 +13,7 @@ In this section, you'll learn how to make your process more dynamic by using BPM
 ## Add Two Gateways
 We want to modify our process so that it's more dynamic.
 
-To do so, open the process in the Camunda Modeler.
+To do so, open the process in the Operaton Modeler.
 
 Next, from the Modeler's left-hand menu, select the gateway shape (diamond) and drag it into position between the Start Event and the Service Task. Use the create space tool again as needed. Move the User Task down and add another Gateway after it. Lastly, adjust the Sequence Flows so that the model looks like this:
 ![Example image](/img/get-started/quick-start/modeler-gateway1.png)
@@ -43,7 +43,7 @@ For the `No` Sequence Flow, use the Expression `${!approved}`:
 
 ## Deploy the Process
 
-Use the `Deploy` Button in the Camunda Modeler to deploy the updated process to Operaton.
+Use the `Deploy` button in the Operaton Modeler to deploy the updated process to Operaton.
 
 ## Work on the Task
 

--- a/docs/get-started/quick-start/index.md
+++ b/docs/get-started/quick-start/index.md
@@ -2,7 +2,7 @@
 
 title: 'Quick Start (Java / JS)'
 sidebar_position: 1
-description: "Learn how to model a BPMN 2.0 process using the Camunda Modeler, adding a Java or JavaScript Worker. Deploy it to the Operaton Platform."
+description: "Learn how to model a BPMN 2.0 process using the Operaton Modeler, adding a Java or JavaScript Worker. Deploy it to the Operaton Platform."
 
 ---
 # Get started with Operaton 
@@ -13,10 +13,10 @@ In this guide, you'll choose between implementing executable processes in Java o
 You will be guided through the following six steps:
 
 ## [Download and Installation](./install.md)
-Install the Operaton Platform and Camunda Modeler on your machine.
+Install the Operaton Platform and Operaton Modeler on your machine.
 
 ## [Executable Process](./service-task.md)
-Learn the basics of handling the Camunda Modeler, learn how to model and configure a fully executable process and learn how to integrate your own business logic.
+Learn the basics of handling the Operaton Modeler, learn how to model and configure a fully executable process and learn how to integrate your own business logic.
 
 ## [Deploy the Process](./deploy.md)
 Deploy the Process to Operaton and start your first process instance.
@@ -29,4 +29,3 @@ Learn how to make your Process more dynamic by adding Gateways to the Process.
 
 ## [Decision Automation](./decision-automation.md)
 Learn how to integrate DMN decision tables in the Process.
-

--- a/docs/get-started/quick-start/user-task.md
+++ b/docs/get-started/quick-start/user-task.md
@@ -13,7 +13,7 @@ In this section, you'll learn how to involve humans in your process by using BPM
 ## Add a User Task
 We want to modify our process so that we can involve humans.
 
-To do so, open the process in the Camunda Modeler.
+To do so, open the process in the Operaton Modeler.
 
 Select the create/remove space tool || from the Modeler's left-hand menu, and use it to create space between the Start Event and the "Charge Credit Card" Service Task (click and drag the cursor to the right).
 
@@ -86,7 +86,7 @@ Finally, save the form as `payment.form`.
 ## Deploy the Process
 
 1. Switch back to the process diagram
-2. Click the Deploy button in the Camunda Modeler
+2. Click the Deploy button in the Operaton Modeler
 3. In the deployment panel, select the `payment.form` file under *include additional files*
 4. Click *Deploy*
 
@@ -111,7 +111,7 @@ You should now see the *Approve Payment* task in your Tasklist. Select the task 
 
 ![Example image](/img/get-started/quick-start/diagram.png)
 
-To work on the task, select the *Form* tab. Because we defined the variables in the Form Tab in the Camunda Modeler, the Tasklist has automatically generated form fields for us.
+To work on the task, select the *Form* tab. Because we defined the variables in the Form tab in the Operaton Modeler, the Tasklist has automatically generated form fields for us.
 
 ![Example image](/img/get-started/quick-start/task-form-generated.png)
 

--- a/docs/get-started/spring-boot/index.md
+++ b/docs/get-started/spring-boot/index.md
@@ -11,6 +11,6 @@ This tutorial guides you through your first steps of using Operaton Platform in 
 
 **Target Audience**:
 In this tutorial we assume that you are familiar with the basics of Java web application development and [Spring Boot](https://spring.io/projects/spring-boot/).
-We also assume that you have installed an Eclipse distribution and the Camunda Modeler.
+We also assume that you have installed an Eclipse distribution and the Operaton Modeler.
 
 You will be guided through the following steps:

--- a/docs/get-started/spring-boot/model.md
+++ b/docs/get-started/spring-boot/model.md
@@ -8,7 +8,7 @@ menu:
     name: "Model a Process"
     parent: "get-started-spring-boot"
     identifier: "get-started-spring-boot-model"
-    description: "Learn the basics of handling the Camunda Modeler and learn how to model and configure a fully executable process."
+    description: "Learn the basics of handling the Operaton Modeler and learn how to model and configure a fully executable process."
 
 ---
 
@@ -26,7 +26,7 @@ model and interact with the process from inside our Spring beans. In this sectio
 
 ### Model an Executable BPMN 2.0 Process and Deploy It
 
-Start by modeling an executable process using the Camunda Modeler. The process should look as depicted in the screenshot below.
+Start by modeling an executable process using the Operaton Modeler. The process should look as depicted in the screenshot below.
 
 ![Example image](/img/get-started/spring-boot/loanApproval.png)
 


### PR DESCRIPTION
## Summary
- rename the modeler installation page from Camunda Modeler to Operaton Modeler
- point modeler documentation references to the Operaton Modeler repository instead of Camunda documentation
- update top-level get-started, quick-start, DMN, Spring Boot, and archived tutorial copy to use Operaton Modeler branding where those files are not covered by other open PRs

## Verification
- `rg -n 'Camunda Modeler|camunda modeler|docs\.camunda\.io/docs/components/modeler' docs/documentation/installation/camunda-modeler.md docs/get-started/index.md docs/get-started/quick-start/index.md docs/get-started/dmn/index.md docs/get-started/spring-boot/index.md docs/get-started/spring-boot/model.md docs/get-started/archive/java-process-app/index.md docs/get-started/archive/java-process-app/model.md docs/get-started/archive/javaee7/model.md docs/get-started/archive/javaee7/start-form.md docs/get-started/archive/spring/index.md docs/get-started/archive/spring/service-task.md docs/get-started/quick-start/gateway.md docs/get-started/quick-start/user-task.md docs/documentation/introduction/index.md docs/documentation/modeling-bpmn/index.md -S`
- `curl -I -L https://github.com/operaton/operaton-modeler`
- `git diff --check`
- `npm run build` (passes; existing unrelated Docusaurus broken-link and broken-anchor warnings remain)