### PR TITLE
Fix BPMN repository service page path

### DIFF
--- a/docs/documentation/user-guide/model-api/bpmn-model-api/repository-service.md
+++ b/docs/documentation/user-guide/model-api/bpmn-model-api/repository-service.md
@@ -11,7 +11,7 @@ menu:
 ---
 
 
-It is also possible to access the BPMN model instance by the process definition id using the [Repository Service](../../../user-guide/process-engine/process-engine-api.md#services-api), as the following incomplete test sample code shows. Please see the [generate-jsf-form](https://github.com/operaton/operaton-bpm-examples/tree/master/bpmn-model-api/generate-jsf-form) quickstart for a complete example.
+It is also possible to access the BPMN model instance by the process definition id using the [Repository Service](../../../user-guide/process-engine/process-engine-api.md#services-api), as the following incomplete test sample code shows.
 
 ```java
 public void testRepositoryService() {


### PR DESCRIPTION
## Summary
- rename the BPMN model API page from `respository-service.md` to `repository-service.md`
- remove the dead `generate-jsf-form` example link, which currently returns 404
- keep the page identifier and visible title unchanged

## Verification
- `rg -n 'respository-service|generate-jsf-form|operaton-bpm-examples/tree/master/bpmn-model-api/generate-jsf-form' docs build/docs/documentation/user-guide/model-api/bpmn-model-api -S`
- `curl -I -L https://github.com/operaton/operaton-bpm-examples/tree/master/bpmn-model-api/generate-jsf-form` returned 404 before removal
- `git diff --check`
- `npm run build` (passes; existing unrelated Docusaurus broken-link and broken-anchor warnings remain)
- `test -f build/docs/documentation/user-guide/model-api/bpmn-model-api/repository-service/index.html`
- `test ! -e build/docs/documentation/user-guide/model-api/bpmn-model-api/respository-service/index.html`