### PR TITLE
Remove dead embedded form example links

### DIFF
--- a/docs/documentation/reference/forms/embedded-forms/java-objects.md
+++ b/docs/documentation/reference/forms/embedded-forms/java-objects.md
@@ -23,7 +23,7 @@ to the embedded form. Java Objects serialized using Java Serialization cannot be
 
 The Form SDK will only fetch those variables which are actually used in a form. Since a Complex Java
 Object is usually not bound to a single input field, we cannot use the `cam-variable-name` directive.
-We thus need to fetch the variable programatically:
+We thus need to fetch the variable programmatically:
 
 ```html
 <script cam-script type="text/form-script">
@@ -50,7 +50,7 @@ In case the variable does not yet exist (for instance in a Start Form), you have
 
   camForm.on('form-loaded', function() {
 
-    // declare variable 'customerData' incuding metadata for serialization
+    // declare variable 'customerData' including metadata for serialization
     camForm.variableManager.createVariable({
       name: 'customerData',
       type: 'Object',
@@ -67,8 +67,3 @@ In case the variable does not yet exist (for instance in a Start Form), you have
 
 </script>
 ```
-
-
-## Full Example
-
-A full example of this feature can be found in the [Operaton Examples Repository](https://github.com/operaton/operaton-bpm-examples/tree/master/usertask/task-form-embedded-serialized-java-object).

--- a/docs/documentation/reference/forms/embedded-forms/json-data.md
+++ b/docs/documentation/reference/forms/embedded-forms/json-data.md
@@ -13,7 +13,7 @@ menu:
 ## Fetching an existing JSON Variable
 
 The Form SDK will only fetch those variables which are actually used in a form. Since a JSON object is usually not bound to a single input field, we cannot use the `cam-variable-name` directive.
-We thus need to fetch the variable programatically:
+We thus need to fetch the variable programmatically:
 
 ```html
 <script cam-script type="text/form-script">
@@ -38,7 +38,7 @@ After that, you can work with the JSON object in your form, e.g., use it in inpu
 
 ## Creating a new JSON Variable
 
-You can use JSON objects in your embedded forms. In order to persist this data in the process instance, you have to explicitely create the variable in the `variableManager`. This code-snippet creates the variable `customer`.
+You can use JSON objects in your embedded forms. In order to persist this data in the process instance, you have to explicitly create the variable in the `variableManager`. This code-snippet creates the variable `customer`.
 
 ```html
 <script cam-script type="text/form-script">
@@ -58,8 +58,3 @@ You can use JSON objects in your embedded forms. In order to persist this data i
   });
 </script>
 ```
-
-
-## Full Example
-
-A full example of this feature can be found in the [Operaton Examples Repository](https://github.com/operaton/operaton-bpm-examples/tree/master/usertask/task-form-embedded-json-variables).


### PR DESCRIPTION
## Summary
- remove dead full-example links to the unavailable `operaton/operaton-bpm-examples` repository from embedded JSON and Java object form docs
- fix nearby spelling in the same embedded form examples

## Verification
- `curl -I -L https://github.com/operaton/operaton-bpm-examples` returns `404`
- `curl -I -L https://github.com/operaton/operaton-bpm-examples/tree/master/usertask/task-form-embedded-json-variables` returns `404`
- `curl -I -L https://github.com/operaton/operaton-bpm-examples/tree/master/usertask/task-form-embedded-serialized-java-object` returns `404`
- `rg -n 'operaton-bpm-examples/tree/master/usertask/task-form-embedded-json-variables|operaton-bpm-examples/tree/master/usertask/task-form-embedded-serialized-java-object|programatically|explicitely|incuding' docs/documentation/reference/forms/embedded-forms/json-data.md docs/documentation/reference/forms/embedded-forms/java-objects.md -S` finds no matches
- `git diff --check`
- `npm run build` (passes with existing Docusaurus broken-link and broken-anchor warnings elsewhere)