### PR TITLE
docs: add 2.1.2 patch release notes

### DIFF
--- a/docs/documentation/reference/release-notes/2_1/index.md
+++ b/docs/documentation/reference/release-notes/2_1/index.md
@@ -427,3 +427,13 @@ RESTEasy 7 is based on **Jakarta REST 4.0** and is the current supported release
 
 This upgrade is completely transparent for clients using the Operaton REST API or the WildFly distribution. 
 No configuration or code changes are required on the client side.
+
+## Patch Releases
+
+### 2.1.2
+
+#### Bug Fixes
+
+- **[fix(engine): use stored process definition key for MDC](https://github.com/operaton/operaton/pull/3109)** — The process definition key used in MDC (Mapped Diagnostic Context) logging is now taken from the stored database value rather than the in-memory object, ensuring consistency in log correlation. (#3109)
+- **[fix(engine): accept date form values](https://github.com/operaton/operaton/pull/3089)** — Engine now correctly handles date-typed form field values submitted via task forms. (#3089)
+- **[fix(engine): prevent attachment delete NPE](https://github.com/operaton/operaton/pull/3088)** — Fixed a NullPointerException when deleting a task attachment that had already been removed. (#3088)


### PR DESCRIPTION
Adds patch release section for 2.1.2 covering three noteworthy bug fixes: MDC process definition key consistency (#3109), date form value handling (#3089), and attachment delete NPE (#3088).

🤖 Generated with [Claude Code](https://claude.com/claude-code)