### PR TITLE
Retire unavailable Maven archetype docs

### DIFF
--- a/docs/documentation/user-guide/process-applications/maven-archetypes.md
+++ b/docs/documentation/user-guide/process-applications/maven-archetypes.md
@@ -13,7 +13,7 @@ menu:
 Maven Archetypes are project templates that can generate a ready-to-use Maven project.
 
 :::caution[Current Availability]
-Operaton does not currently publish public Maven archetype artifacts or an archetype catalog. Older documentation pointed to a Camunda Artifactory repository and to a former archetype template repository, but those locations are not available for Operaton and should not be used.
+Operaton does not currently publish public Maven archetype artifacts or an archetype catalog. Older documentation pointed to artifact and template repositories that are not available for Operaton and should not be used.
 :::
 
 ## Recommended Project Setup

--- a/docs/documentation/user-guide/process-applications/maven-archetypes.md
+++ b/docs/documentation/user-guide/process-applications/maven-archetypes.md
@@ -10,148 +10,35 @@ menu:
 
 ---
 
-We provide several project templates for Maven, which are also called Archetypes.
-They enable a quickstart for developing production-ready process applications using Operaton.
-We incorporated best practices for different application types into the templates to help you start off with a solid base.
+Maven Archetypes are project templates that can generate a ready-to-use Maven project.
 
-The Archetypes can be used to generate projects as detailed in the different usage sections.
-In case generating a project from an Archetype on your own is not feasible, we also provide a template GitHub repository for every Archetype.
+:::caution[Current Availability]
+Operaton does not currently publish public Maven archetype artifacts or an archetype catalog. Older documentation pointed to a Camunda Artifactory repository and to a former archetype template repository, but those locations are not available for Operaton and should not be used.
+:::
 
-## Overview of Available Maven Archetypes
+## Recommended Project Setup
 
-The following archetypes are currently provided. They are distributed via our Maven repository: https://artifacts.camunda.com/artifactory/operaton-bpm/
+Use the manual project setup guides instead. They show the current Maven dependencies and project structure directly:
 
-<table class="table table-bordered">
-  <thead>
-    <tr><th>Archetype</th><th>Description</th></tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><a href="https://artifacts.camunda.com/artifactory/operaton-bpm/org/operaton/bpm/archetype/operaton-archetype-cockpit-plugin/">Operaton Cockpit Plugin</a></td>
-      <td>Plugin for Operaton Cockpit, contains REST-Backend, MyBatis database query, HTML and JavaScript frontend, Ant build script for one-click deployment</td>
-    </tr>
-    <tr>
-      <td><a href="https://artifacts.camunda.com/artifactory/operaton-bpm/org/operaton/bpm/archetype/operaton-archetype-ejb-war/">Process Application (EJB, WAR)</a></td>
-      <td>Process application that uses a shared Operaton engine in a Java EE Container, e.g., WildFly.
-          Contains: Operaton EJB Client, Operaton CDI Integration, BPMN Process, Java Delegate as CDI bean, HTML5- & JSF-based start and task forms,
-          configuration for JPA (Hibernate), JUnit Test with in-memory engine and visual process test coverage, Arquillian Test for WildFly, Maven Plugins or Ant build script for one-click deployment in Eclipse</td>
-    </tr>
-    <tr>
-      <td><a href="https://artifacts.camunda.com/artifactory/operaton-bpm/org/operaton/bpm/archetype/operaton-archetype-servlet-war/">Process Application (Servlet, WAR)</a></td>
-      <td>Process application that uses a shared Operaton engine in a Servlet Container, e.g., Apache Tomcat.
-          Contains: Servlet process application, BPMN Process, Java Delegate, HTML5-based start and task forms,
-          JUnit Test with in-memory engine, Maven Plugins or Ant build script for one-click deployment in Eclipse</td>
-    </tr>
-    <tr>
-      <td><a href="https://artifacts.camunda.com/artifactory/operaton-bpm/org/operaton/bpm/archetype/operaton-archetype-spring-boot/">Operaton Spring Boot Application</a></td>
-      <td>Application that uses the Operaton Spring Boot Starter.
-          Contains: Spring Boot Process Application, Operaton Webapps, BPMN Process, Java Delegate, HTML5-based start and task forms,
-          JUnit Test with in-memory engine, Maven Plugins for packing as an executable application.</td>
-    </tr>
-    <tr>
-      <td><a href="https://artifacts.camunda.com/artifactory/operaton-bpm/org/operaton/bpm/archetype/operaton-archetype-spring-boot-demo/">Operaton Spring Boot Application with Demo Users</a></td>
-      <td>Same as the <i>Spring Boot Application</i> archetype and additionally creates demo users and groups for easy start with the Operaton Webapps (use <code>demo/demo</code> to log in).</td>
-    </tr>
-    <tr>
-      <td><a href="https://artifacts.camunda.com/artifactory/operaton-bpm/org/operaton/bpm/archetype/operaton-archetype-engine-plugin/">Process Engine Plugin</a></td>
-      <td>An example for a process engine plugin.
-      Contains: Process engine plugin, BPMN Parse Listener that is registered via the plugin, Task Listener that is added to every user task, JUnit Test with in-memory engine.</td>
-    </tr>
-  </tbody>
-</table>
+| Use case | Setup guide |
+| --- | --- |
+| BPMN process application on Tomcat | [Java process application project setup](/docs/get-started/archive/java-process-app/project-setup/) |
+| Java EE process application on WildFly | [Java EE project setup](/docs/get-started/archive/javaee7/project-setup/) |
+| DMN project | [DMN project setup](/docs/get-started/dmn/project-setup/) |
+| Spring Boot application | [Spring Boot project setup](/docs/get-started/spring-boot/project-setup/) |
+| Dependency versions | [Apache Maven and the Operaton BOM](/docs/get-started/apache-maven/) |
 
-## Template repositories
+## Historical Archetype Names
 
-We provide a template repository for every Operaton Archetype.
-Every repository contains a project generated from one specific template.
-You can find the whole list on [GitHub](https://github.com/camunda?q=%22operaton-bpm-archetype-%22).
+Some older Operaton or Camunda 7 material may mention these archetype artifact IDs:
 
-With every new release of the Archetypes, we will update those repositories with a new version as well.
-This allows to investigate possible update paths from one Operaton version to another and also enables you to simply update your existing project by pulling in the latest changes.
+| Artifact ID | Intended use |
+| --- | --- |
+| `operaton-archetype-cockpit-plugin` | Cockpit plugin project |
+| `operaton-archetype-ejb-war` | Java EE process application packaged as WAR |
+| `operaton-archetype-servlet-war` | Servlet process application packaged as WAR |
+| `operaton-archetype-spring-boot` | Spring Boot process application |
+| `operaton-archetype-spring-boot-demo` | Spring Boot process application with demo users |
+| `operaton-archetype-engine-plugin` | Process engine plugin project |
 
-In case you need more flexibility and customization for your project, you can generate a project on your own using one of the methods detailed in the next sections.
-
-## Usage in Eclipse IDE
-
-### Summary
-
-1. Add archetype catalog (**Preferences -> Maven -> Archetypes -> Add Remote Catalog**):
-    **https://artifacts.camunda.com/artifactory/operaton-bpm/**
-2. Create Maven project from archetype (**File -> New -> Project... -> Maven -> Maven Project**)
-
-
-### Detailed Instructions
-
-1. Go to **Preferences -> Maven -> Archetypes -> Add Remote Catalog**
-![Example img](/img/documentation/user-guide/process-applications/eclipse-00-preferences-maven-archetypes.png)Eclipse Preferences: Maven Archetypes
-2. Enter the following URL and description, click on **Verify...** to test the connection and if that worked click on **OK** to save the catalog.
-
-    Catalog File: **https://artifacts.camunda.com/artifactory/operaton-bpm/**
-
-    Description: **Operaton**
-![Example img](/img/documentation/user-guide/process-applications/eclipse-01-add-remote-archetype-catalog.png)Eclipse Preferences: Add Maven Archetype Catalog
-
-Now you should be able to use the archetypes when creating a new Maven project in Eclipse:
-
-1. Go to **File -> New -> Project...** and select **Maven -> Maven Project**
-![Example img](/img/documentation/user-guide/process-applications/eclipse-02-create-maven-project.png)Create new Maven project
-2. Select a location for the project or just keep the default setting.
-![Example img](/img/documentation/user-guide/process-applications/eclipse-03-select-maven-project-location.png)Eclipse: Select Maven project location
-3. Select the archetype from the catalog that you created before.
-![Example img](/img/documentation/user-guide/process-applications/eclipse-04-select-archetype-from-catalog.png)Eclipse: Select Maven archetype from catalog
-4. Specify Maven coordinates and Operaton version and finish the project creation.
-![Example img](/img/documentation/user-guide/process-applications/eclipse-05-specify-maven-coordinates-and-operaton-version.png)Eclipse: Specify Maven coordinates and Operaton version
-
-The resulting project should look like this:
-
-![Example img](/img/documentation/user-guide/process-applications/eclipse-06-generated-maven-project.png)Generated Maven Project in Eclipse
-
-
-### Troubleshooting
-
-Sometimes the creation of the very first Maven project fails in Eclipse. If that happens to you, just try it again. Most of the times the second try works. If the problem persists, [contact us](https://forum.operaton.org/).
-
-## Usage in IntelliJ IDEA
-
-1. On the "Welcome to IntelliJ IDEA" screen, click on "Configure" and select "Plugins" in the dropdown.
-2. In the plugins dialog, click on "Browse repositories...".
-3. Search for the plugin "Maven Archetype Catalogs" and click on "Install".
-4. Restart IntelliJ IDEA.
-5. On the "Welcome to IntelliJ IDEA" screen, click on "Configure" and select "Preferences" in the dropdown.
-6. In the preferences window, navigate to: "Build, Execution, Deployment > Build Tools > Maven Archetype Catalogs".
-7. In the Maven Archetype Catalogs window, click on the "+" button, and in the opened "Add Archetype Catalog URL"
-   modal window add the  URL of the catalog file: https://artifacts.camunda.com/artifactory/operaton-bpm/archetype-catalog.xml.
-8. To create a Maven project from an archetype, click on the "Welcome to IntelliJ IDEA" screen on "Create New Project".
-9. In the new project dialog, click on the left side on "Maven", check "Create from archetype"
-   and select any `org.operaton.bpm.archetype` entry.
-
-## Usage on Command Line
-
-### Interactive
-
-Run the following command in a terminal to generate a project. Maven will allow you to select an archetype and ask you for all parameters needed to configure it:
-
-<pre class="console">
-mvn archetype:generate -Dfilter=org.operaton.bpm.archetype:
-</pre>
-
-
-### Full Automation
-
-The following command completely automates the project generation and can be used in shell scripts or Ant builds:
-<pre class="console">
-mvn archetype:generate \
-  -DinteractiveMode=false \
-  -DarchetypeGroupId=org.operaton.bpm.archetype \
-  -DarchetypeArtifactId=operaton-archetype-ejb-war \
-  -DarchetypeVersion=7.10.0 \
-  -DgroupId=org.example.operaton.bpm \
-  -DartifactId=operaton-bpm-ejb-project \
-  -Dversion=0.0.1-SNAPSHOT \
-  -Dpackage=org.example.operaton.bpm.ejb
-</pre>
-
-
-## Source Code and Customization
-
-You can also customize the project templates for your own technology stack. Just [fork them on GitHub](https://github.com/operaton/operaton-archetypes)!
+Treat these names as historical until Operaton publishes a public archetype catalog again. For new applications, start from the setup guides above and import the Operaton BOM from Maven Central.

--- a/docs/documentation/user-guide/process-applications/the-process-application-class.md
+++ b/docs/documentation/user-guide/process-applications/the-process-application-class.md
@@ -55,9 +55,7 @@ Notice the `@ProcessApplication` annotation. This annotation fulfills two purpos
 
 This means that in case you deploy to a Servlet 3.0 compliant container (such as Apache Tomcat) annotating your class with `@ProcessApplication` is sufficient.
 
-:::note
-  There is a [project template for Maven](../../user-guide/process-applications/maven-archetypes.md) called ```operaton-archetype-servlet-war```, which gives you a complete running project based on a servlet process application.
-:::
+For a complete servlet process application project, follow the [Java process application project setup](/docs/get-started/archive/java-process-app/project-setup/).
 
 ### Using Servlet process applications inside an EJB/Jakarta EE/Java EE container such as Wildfly
 
@@ -139,9 +137,9 @@ You could of course use something like the maven shade plugin for adding the cla
 
 :::note
   We always recommend using the Operaton EJB Client over deploying a custom `EjbProcessApplication` class unless you want to customize the behavior of the `EjbProcessApplication`.
-
-  There is a [project template for Maven](../../user-guide/process-applications/maven-archetypes.md) called ```operaton-archetype-servlet-war```, which gives you a complete running project based on a Java EE servlet process application.
 :::
+
+For a complete Java EE process application project, follow the [Java EE project setup](/docs/get-started/archive/javaee7/project-setup/).
 
 
 ### Deploying a Custom `EjbProcessApplication` Class

--- a/docs/documentation/user-guide/testing/index.md
+++ b/docs/documentation/user-guide/testing/index.md
@@ -342,11 +342,13 @@ import static org.assertj.core.api.Assertions.*;
 
 ## Community extensions to support testing
 
-There are a couple of well documented and heavily used community extensions that can make testing much more productive and fun.
+The following historical community extensions may be useful references, but they are not maintained as Operaton-owned projects.
 
-### Operaton Scenario Tests
+### Scenario Tests
 
-[Operaton-bpm-assert-scenario](https://github.com/operaton/operaton-bpm-assert-scenario/) enables you to write more robust test suites. The idea is, that you only have to adapt your tests if your process models changes in a way that affects the tested behavior. It concentrates much less on the concrete path through a given process model, but on the external effects the path through the model has.
+Operaton does not currently publish an Operaton-owned scenario testing extension. If you relied on this type of extension before migrating, the historical upstream project is now [Camunda Platform Scenario](https://github.com/camunda-community-hub/camunda-platform-scenario). Validate compatibility with your Operaton version before using it.
+
+Scenario tests help you write more robust test suites. The idea is that you only have to adapt your tests if your process models change in a way that affects the tested behavior. They concentrate much less on the concrete path through a given process model, but on the external effects the path through the model has.
 
 ```java
 @Test
@@ -362,9 +364,11 @@ public void testHappyPath() {
 }
 ```
 
-### Operaton Test Coverage
+### Process Test Coverage
 
-[Operaton-bpm-process-test-coverage](https://github.com/operaton/operaton-bpm-process-test-coverage/) visualises test process pathes and checks your process model coverage ratio. Running typical JUnit tests leaves html files in the build output.
+Operaton does not currently publish an Operaton-owned process test coverage extension. The historical upstream project is [Camunda Process Test Coverage](https://github.com/camunda-community-hub/camunda-process-test-coverage), which is archived. Treat it as a compatibility reference and validate it carefully before using it with Operaton.
+
+Process test coverage extensions visualize test process paths and check your process model coverage ratio. Running typical JUnit tests leaves HTML files in the build output.
 
 
 ## Resolving Beans Without Spring/CDI

--- a/docs/documentation/user-guide/testing/index.md
+++ b/docs/documentation/user-guide/testing/index.md
@@ -272,16 +272,16 @@ Also, you will have to add the AssertJ library to your dependencies. Make sure t
 </dependency>
 ```
 
-If Operaton Assert is used in combination with [Spring Boot](https://spring.io/projects/spring-boot) or the 
-[Operaton Spring Boot Starter](https://docs.operaton.org/docs/documentation/user-guide/spring-boot-integration/), 
+If Operaton Assert is used in combination with [Spring Boot](https://spring.io/projects/spring-boot) or the
+[Operaton Spring Boot Starter](../spring-boot-integration/),
 the AssertJ dependency will be present in your project already.
 
 ### Assertions Version Compatibility
 
 Each version of Operaton Assert is bound to a specific version of Operaton and AssertJ. Only these default combinations are recommended (and supported) by Operaton.
 Nevertheless, each version of Operaton Assert can be combined with newer patch versions of the Operaton engine, though such combinations must be thoroughly tested before being used in production.
-All versions prior to 3.0.0 belong to the community extension are not part of the official Operaton product support.
-With Operaton.17.0 the project was moved into the [Operaton repository](https://github.com/operaton/operaton) and will use the same versioning as Operaton in the future.
+All versions prior to 3.0.0 belong to the community extension and are not part of the official Operaton product support.
+With Camunda 7.17.0, the project was moved into the platform repository; Operaton now maintains it in the [Operaton repository](https://github.com/operaton/operaton) and uses the same versioning as Operaton.
 
 <table class="table table-striped">
   <tr>

--- a/docs/documentation/user-guide/testing/index.md
+++ b/docs/documentation/user-guide/testing/index.md
@@ -140,9 +140,7 @@ public class MyBusinessProcessTest {
 }
 ```
 
-:::note
-  Our [Project Templates for Maven](../../user-guide/process-applications/maven-archetypes.md) give you a complete running project including a JUnit test out of the box.
-:::
+The [Java process application project setup](/docs/get-started/archive/java-process-app/project-setup/) shows a complete project structure that you can extend with tests like the examples below.
 
 
 ### JUnit 3

--- a/docs/get-started/archive/java-process-app/project-setup.md
+++ b/docs/get-started/archive/java-process-app/project-setup.md
@@ -16,10 +16,6 @@ Now you are ready to set up your first process application project in the IDE of
 
 ## Create a new Maven Project
 
-:::note[Fancy to save work and use a project template instead?]
-You don't have to setup the project manually but can also use a Maven Archetype (which is like a project template), see [Maven Archetypes](/docs/documentation/user-guide/process-applications/maven-archetypes/) for details. The archetype will create a project according to our best practices.
-:::
-
 In Eclipse, go to `File / New / Other ...`. This opens the *New Project Wizard*. In the *New Project Wizard* select `Maven / Maven Project`. Click Next.
 
 ![Example image](/img/get-started/archive/java-process-app/eclipse-new-project.png)

--- a/docs/get-started/archive/javaee7/project-setup.md
+++ b/docs/get-started/archive/javaee7/project-setup.md
@@ -16,10 +16,6 @@ Now you are ready to set up your first process application project in the IDE of
 
 ## Set up your project
 
-:::note[Fancy to save work and use a project template instead?]
-You don't have to setup the project manually but can also use a Maven Archetype (which is like a project template), see [Maven Archetypes](/docs/documentation/user-guide/process-applications/maven-archetypes/) for details. The archetype will create a project according to our best practices.
-:::
-
 Now you are ready to set up your Java EE process application project in Eclipse. Setting up a process application project consists of 6 steps:
 
 1. Create a new Maven Project in Eclipse

--- a/docs/get-started/archive/javaee7/project-setup.md
+++ b/docs/get-started/archive/javaee7/project-setup.md
@@ -141,7 +141,7 @@ Now you can perform the first build. Select the `pom.xml` in the Package Explore
 
 ### Add a WEB-INF/beans.xml Deployment Descriptor
 
-After we have all of our Maven dependencies configured, we can add our first deployment descriptor. The `WEB-INF/beans.xml` is used to configure a CDI application. Its presence is always mandatory but it can be empty, as it is in our case. For further information, please see [this explanation](http://www.cdi-spec.org/faq/).
+After we have all of our Maven dependencies configured, we can add our first deployment descriptor. The `WEB-INF/beans.xml` is used to configure a CDI application. Its presence is always mandatory but it can be empty, as it is in our case. For further information, please see [this explanation](https://www.cdi-spec.org/faq/).
 
 This file needs to be added to the `src/main/webapp/WEB-INF` folder of the Maven project.
 

--- a/docs/get-started/archive/javaee7/project-setup.md
+++ b/docs/get-started/archive/javaee7/project-setup.md
@@ -141,7 +141,7 @@ Now you can perform the first build. Select the `pom.xml` in the Package Explore
 
 ### Add a WEB-INF/beans.xml Deployment Descriptor
 
-After we have all of our maven dependencies configured, we can add our first deployment descriptor. The `WEB-INF/beans.xml` is used to configure a CDI application. It's presence is always mandatory but it can be empty, as it is in our case. For further information, please see [this explanation](http://www.cdi-spec.org/faq/).
+After we have all of our Maven dependencies configured, we can add our first deployment descriptor. The `WEB-INF/beans.xml` is used to configure a CDI application. Its presence is always mandatory but it can be empty, as it is in our case. For further information, please see [this explanation](http://www.cdi-spec.org/faq/).
 
 This file needs to be added to the `src/main/webapp/WEB-INF` folder of the Maven project.
 

--- a/docs/get-started/dmn/project-setup.md
+++ b/docs/get-started/dmn/project-setup.md
@@ -21,12 +21,6 @@ DMN is a modeling language for *decisions*, whereas BPMN is a language for *proc
 
 ## Create a new Maven Project
 
-:::note[Fancy to save work and use a project template instead?]
-
-You don't have to setup the project manually but can also use a Maven Archetype (which is like a project template), see [Maven Archetypes](/docs/documentation/user-guide/process-applications/maven-archetypes/) for details. The archetype will create a project according to our best practices.
-
-:::
-
 In Eclipse, go to `File / New / Other ...`. This opens the *New Project Wizard*. In the *New Project Wizard* select `Maven / Maven Project`. Click Next.
 
 ![Example image](/img/get-started/dmn/eclipse-new-project.png)


### PR DESCRIPTION
## Summary
- retire the unavailable Maven archetype repository/catalog instructions instead of pointing users at dead Operaton archetype resources
- replace old Camunda Artifactory/catalog setup with guidance to create projects directly from the current Operaton dependencies
- replace the stale public Spring Boot self-link in the testing guide with the local Spring Boot integration page
- clarify Operaton Assert history with the correct Camunda 7.17.0 reference and current Operaton repository wording
- clarify that Operaton does not currently publish Operaton-owned scenario testing or process test coverage extension repositories, and link only to the historical upstream community projects as compatibility references

## Verification
- `gh repo view operaton/operaton-archetypes` returns not found
- `gh repo view operaton/operaton-bpm-assert-scenario` returns not found
- `gh repo view operaton/operaton-bpm-process-test-coverage` returns not found
- `gh repo view camunda-community-hub/camunda-platform-scenario --json nameWithOwner,isArchived,url,description` confirms the historical scenario project exists and is not archived
- `gh repo view camunda-community-hub/camunda-process-test-coverage --json nameWithOwner,isArchived,url,description` confirms the historical process test coverage project exists and is archived
- `curl -fsI -L --max-time 20 https://github.com/camunda-community-hub/camunda-platform-scenario` returns HTTP 200
- `curl -fsI -L --max-time 20 https://github.com/camunda-community-hub/camunda-process-test-coverage` returns HTTP 200
- `curl -fsI -L https://github.com/camunda/camunda-bpm-platform/tree/7.17.0/test-utils/assert` returns HTTP 200
- `curl -fsI -L https://github.com/camunda/camunda-bpm-platform/tree/7.16.0/test-utils/assert` returns HTTP 404
- `rg -n "operaton-archetypes|operaton-bpm-assert-scenario|operaton-bpm-process-test-coverage|Operaton\\.17\\.0|docs\\.operaton\\.org/docs/documentation/user-guide/spring-boot-integration|pathes|visualises|html files|well documented|heavily used" docs/documentation/user-guide/process-applications/maven-archetypes.md docs/documentation/user-guide/testing/index.md -S` returns no matches
- `rg -n "Camunda 7.17.0|Camunda Platform Scenario|Camunda Process Test Coverage|Operaton-owned" docs/documentation/user-guide/testing/index.md -S` confirms the replacement wording
- `git diff --check`
- `npm run typecheck`
- `npm run build` succeeds; Docusaurus still reports the known pre-existing broken link/anchor warnings handled separately in #115
