### PR TITLE
Remove Enterprise references from release notes

### DIFF
--- a/docs/documentation/reference/release-notes/1_0/index.md
+++ b/docs/documentation/reference/release-notes/1_0/index.md
@@ -15,19 +15,19 @@ transition. Multiple products have already started to use Operaton in production
 more are actively testing it. Major effort has been put into **automated testing to ensure stability
 and reliability**.
 
-From now on, Operaton is the successor to the open-source BPM platform formerly known as
-_Camunda 7 Community Edition_ (archived on Nov 4th 2025).
+From now on, Operaton is the successor to the open-source Camunda 7 BPM platform
+(archived on Nov 4th 2025).
 The engine is already battle-tested in production environments,
-and is safe to transition from existing Camunda 7 CE installations.
+and is safe to transition from existing open-source Camunda 7 installations.
 It is important to note that Operaton focuses on the core BPM/CMMN/DMN engine and its related components.
 
 We are excited to embark on this new journey and look forward to building a vibrant
 community around Operaton. We welcome contributions, feedback, and collaboration from developers
 worldwide. Together, we can shape the future of business process management with Operaton!
 
-## 🛠️ Migration from Camunda 7 CE
+## 🛠️ Migration from Camunda 7
 
-Migrating from Camunda 7 Community Edition to Operaton is straightforward. Operaton 1.0 is fully
+Migrating from Camunda 7 to Operaton is straightforward. Operaton 1.0 is fully
 compatible with Camunda 7.24, allowing for a seamless transition. We recommend upgrading to
 Camunda 7.24 first, and then switch to Operaton 1.0.
 
@@ -60,7 +60,7 @@ Operaton is tested and supported on **Java 17**, **Java 21**, and **Java 25**.
 
 ### Camunda 7 Compatibility
 
-This release is feature complete and API-compatible with [**Camunda 7.24**](https://docs.camunda.org/enterprise/announcement/#camunda-platform-7-24).
+This release is feature complete and API-compatible with [**Camunda 7.24**](https://docs.camunda.org/manual/7.24/).
 
 ### Spring
 

--- a/docs/documentation/reference/release-notes/1_0/index.md
+++ b/docs/documentation/reference/release-notes/1_0/index.md
@@ -7,7 +7,7 @@ sidebar_position: 10
 
 # About release 1.0
 
-This is the first official, stable release of Operaton. After forking the [Camunda 7 Community Edition codebase](https://github.com/camunda/camunda-bpm-platform) in 2024,
+This is the first official, stable release of Operaton. After forking the [Camunda 7 platform](https://github.com/camunda/camunda-bpm-platform) in 2024,
 we have been working hard to modernize the code base and prepare for the 1.0.0 stable release.
 
 Several beta releases have been published to gather feedback from the community and ensure a smooth
@@ -37,7 +37,7 @@ in our [Operaton Migration Repository](https://github.com/operaton/migrate-from-
 
 ## 📊 Facts & Numbers
 
-Since forking [Camunda 7 Community Edition](https://github.com/camunda/camunda-bpm-platform) in 2024, we have made significant progress in modernizing the codebase. Here are some key statistics:
+Since forking [Camunda 7 Platform](https://github.com/camunda/camunda-bpm-platform) in 2024, we have made significant progress in modernizing the codebase. Here are some key statistics:
 
 - **Battle-Tested**: Operaton is already in production use by multiple organizations, showcasing its reliability and performance in real-world scenarios.
 - **Commits**: Over **1,500 commits** have been made to the Operaton codebase since initiation of the fork until this release.

--- a/docs/documentation/reference/release-notes/1_0/index.md
+++ b/docs/documentation/reference/release-notes/1_0/index.md
@@ -60,7 +60,7 @@ Operaton is tested and supported on **Java 17**, **Java 21**, and **Java 25**.
 
 ### Camunda 7 Compatibility
 
-This release is feature complete and API-compatible with [**Camunda 7.24**](https://docs.camunda.org/manual/7.24/).
+This release is feature complete and API-compatible with [**Camunda 7 CE 7.24**](https://docs.camunda.org/manual/7.24/).
 
 ### Spring
 

--- a/docs/documentation/reference/release-notes/1_0/index.md
+++ b/docs/documentation/reference/release-notes/1_0/index.md
@@ -7,7 +7,7 @@ sidebar_position: 10
 
 # About release 1.0
 
-This is the first official, stable release of Operaton. After forking the [Camunda 7 platform](https://github.com/camunda/camunda-bpm-platform) in 2024,
+This is the first official, stable release of Operaton. After forking the [Camunda 7 Community Edition codebase](https://github.com/camunda/camunda-bpm-platform) in 2024,
 we have been working hard to modernize the code base and prepare for the 1.0.0 stable release.
 
 Several beta releases have been published to gather feedback from the community and ensure a smooth
@@ -37,7 +37,7 @@ in our [Operaton Migration Repository](https://github.com/operaton/migrate-from-
 
 ## 📊 Facts & Numbers
 
-Since forking [Camunda 7 Platform](https://github.com/camunda/camunda-bpm-platform) in 2024, we have made significant progress in modernizing the codebase. Here are some key statistics:
+Since forking [Camunda 7 Community Edition](https://github.com/camunda/camunda-bpm-platform) in 2024, we have made significant progress in modernizing the codebase. Here are some key statistics:
 
 - **Battle-Tested**: Operaton is already in production use by multiple organizations, showcasing its reliability and performance in real-world scenarios.
 - **Commits**: Over **1,500 commits** have been made to the Operaton codebase since initiation of the fork until this release.

--- a/docs/documentation/reference/release-notes/1_0/index.md
+++ b/docs/documentation/reference/release-notes/1_0/index.md
@@ -15,19 +15,19 @@ transition. Multiple products have already started to use Operaton in production
 more are actively testing it. Major effort has been put into **automated testing to ensure stability
 and reliability**.
 
-From now on, Operaton is the successor to the open-source Camunda 7 BPM platform
-(archived on Nov 4th 2025).
+From now on, Operaton is the successor to the open-source BPM platform formerly known as
+_Camunda 7 Community Edition_ (archived on Nov 4th 2025).
 The engine is already battle-tested in production environments,
-and is safe to transition from existing open-source Camunda 7 installations.
+and is safe to transition from existing Camunda 7 CE installations.
 It is important to note that Operaton focuses on the core BPM/CMMN/DMN engine and its related components.
 
 We are excited to embark on this new journey and look forward to building a vibrant
 community around Operaton. We welcome contributions, feedback, and collaboration from developers
 worldwide. Together, we can shape the future of business process management with Operaton!
 
-## 🛠️ Migration from Camunda 7
+## 🛠️ Migration from Camunda 7 CE
 
-Migrating from Camunda 7 to Operaton is straightforward. Operaton 1.0 is fully
+Migrating from Camunda 7 Community Edition to Operaton is straightforward. Operaton 1.0 is fully
 compatible with Camunda 7.24, allowing for a seamless transition. We recommend upgrading to
 Camunda 7.24 first, and then switch to Operaton 1.0.
 

--- a/docs/documentation/reference/release-notes/1_1/index.md
+++ b/docs/documentation/reference/release-notes/1_1/index.md
@@ -57,7 +57,7 @@ Operaton is tested and supported on **Java 17**, **Java 21**, and **Java 25**.
 
 ### Camunda 7 Compatibility
 
-This release is feature complete and API-compatible with [**Camunda 7.24**](https://docs.camunda.org/manual/7.24/).
+This release is feature complete and API-compatible with [**Camunda 7 CE 7.24**](https://docs.camunda.org/manual/7.24/).
 
 ### Spring
 

--- a/docs/documentation/reference/release-notes/1_1/index.md
+++ b/docs/documentation/reference/release-notes/1_1/index.md
@@ -57,7 +57,7 @@ Operaton is tested and supported on **Java 17**, **Java 21**, and **Java 25**.
 
 ### Camunda 7 Compatibility
 
-This release is feature complete and API-compatible with [**Camunda 7.24**](https://docs.camunda.org/enterprise/announcement/#camunda-platform-7-24).
+This release is feature complete and API-compatible with [**Camunda 7.24**](https://docs.camunda.org/manual/7.24/).
 
 ### Spring
 

--- a/docs/documentation/reference/release-notes/2_0/index.md
+++ b/docs/documentation/reference/release-notes/2_0/index.md
@@ -116,7 +116,7 @@ Operaton is tested and supported on **Java 17**, **Java 21**, and **Java 25**.
 
 ### Camunda 7 Compatibility
 
-This release is feature complete and API-compatible with [**Camunda 7.24**](https://docs.camunda.org/manual/7.24/).
+This release is feature complete and API-compatible with [**Camunda 7 CE 7.24**](https://docs.camunda.org/manual/7.24/).
 
 ### Spring
 

--- a/docs/documentation/reference/release-notes/2_0/index.md
+++ b/docs/documentation/reference/release-notes/2_0/index.md
@@ -116,7 +116,7 @@ Operaton is tested and supported on **Java 17**, **Java 21**, and **Java 25**.
 
 ### Camunda 7 Compatibility
 
-This release is feature complete and API-compatible with [**Camunda 7.24**](https://docs.camunda.org/enterprise/announcement/#camunda-platform-7-24).
+This release is feature complete and API-compatible with [**Camunda 7.24**](https://docs.camunda.org/manual/7.24/).
 
 ### Spring
 

--- a/docs/documentation/reference/release-notes/2_1/index.md
+++ b/docs/documentation/reference/release-notes/2_1/index.md
@@ -350,7 +350,7 @@ Operaton is tested and supported on **Java 17**, **Java 21**, and **Java 25**.
 
 ### Camunda 7 Compatibility
 
-This release is feature complete and API-compatible with [**Camunda 7.24**](https://docs.camunda.org/manual/7.24/).
+This release is feature complete and API-compatible with [**Camunda 7 CE 7.24**](https://docs.camunda.org/manual/7.24/).
 
 ### Spring
 

--- a/docs/documentation/reference/release-notes/2_1/index.md
+++ b/docs/documentation/reference/release-notes/2_1/index.md
@@ -350,7 +350,7 @@ Operaton is tested and supported on **Java 17**, **Java 21**, and **Java 25**.
 
 ### Camunda 7 Compatibility
 
-This release is feature complete and API-compatible with [**Camunda 7.24**](https://docs.camunda.org/enterprise/announcement/#camunda-platform-7-24).
+This release is feature complete and API-compatible with [**Camunda 7.24**](https://docs.camunda.org/manual/7.24/).
 
 ### Spring
 

--- a/docs/documentation/reference/release-notes/2_2/index.md
+++ b/docs/documentation/reference/release-notes/2_2/index.md
@@ -104,7 +104,7 @@ Operaton is tested and supported on **Java 17**, **Java 21**, and **Java 25**.
 
 ### Camunda 7 Compatibility
 
-This release is feature complete and API-compatible with [**Camunda 7.24**](https://docs.camunda.org/manual/7.24/).
+This release is feature complete and API-compatible with [**Camunda 7 CE 7.24**](https://docs.camunda.org/manual/7.24/).
 
 ### Spring
 

--- a/docs/documentation/reference/release-notes/2_2/index.md
+++ b/docs/documentation/reference/release-notes/2_2/index.md
@@ -104,7 +104,7 @@ Operaton is tested and supported on **Java 17**, **Java 21**, and **Java 25**.
 
 ### Camunda 7 Compatibility
 
-This release is feature complete and API-compatible with [**Camunda 7.24**](https://docs.camunda.org/enterprise/announcement/#camunda-platform-7-24).
+This release is feature complete and API-compatible with [**Camunda 7.24**](https://docs.camunda.org/manual/7.24/).
 
 ### Spring
 


### PR DESCRIPTION
## Summary
- replace the five Camunda Enterprise announcement URLs in Operaton release notes with the neutral Camunda 7.24 manual URL
- label the compatibility target as Camunda 7 CE 7.24
- leave Java EE/Jakarta EE and `javax.enterprise` technical terminology untouched

## Verification
- `rg -n -i "docs\.camunda\.org/enterprise|enterprise/announcement|Enterprise Edition|Camunda Enterprise|Operaton Enterprise|Operaton Enterprise Edition|Camunda 7 Enterprise" docs -S` finds no product/edition matches
- `rg -n -i "\\benterprise\\b" docs -S` only returns Java/Jakarta/JBoss technical terms
- `git diff --check`
- `npm run typecheck`
- `npm run build` succeeds; Docusaurus still reports known pre-existing broken link/anchor warnings handled separately in #115