### PR TITLE
Add local Typesense HTTPS setup to reproduce and document fix for #161

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ yarn-error.log*
 .idea
 
 .env
+
+# Local Typesense dev server (see docker/typesense)
+/docker/typesense/certs
+/docker/typesense/data

--- a/README.md
+++ b/README.md
@@ -36,3 +36,85 @@ npm run typecheck
 ```
 
 Run the typecheck and production build before opening a pull request.
+
+## Local Search (Typesense) Setup
+
+The production site queries a Typesense server directly from the browser
+(`typesenseServerConfig` in `docusaurus.config.ts`), over **HTTPS** on port
+`8108`. To develop or test the search integration locally — including
+reproducing HTTPS/CORS issues like
+[#161](https://github.com/operaton/documentation/issues/161) — run a local
+Typesense instance with TLS enabled via Docker Compose.
+
+### 1. Generate a local TLS certificate
+
+```bash
+./docker/typesense/generate-certs.sh
+```
+
+This creates a self-signed certificate/key in `docker/typesense/certs/`
+(git-ignored). Typesense terminates TLS itself using this certificate,
+the same way the production server must be configured.
+
+### 2. Configure an API key
+
+```bash
+echo "TYPESENSE_API_KEY=some-local-dev-key" > docker/typesense/.env
+```
+
+### 3. Start Typesense
+
+```bash
+cd docker/typesense
+docker compose up -d
+```
+
+Verify it's serving HTTPS correctly:
+
+```bash
+curl -sk https://localhost:8108/health
+# {"ok":true}
+```
+
+### 4. Point Docusaurus at the local server
+
+Create a `.env` file in the repository root (git-ignored):
+
+```bash
+TYPESENSE_API_KEY=some-local-dev-key
+TYPESENSE_HOST=localhost
+TYPESENSE_PORT=8108
+TYPESENSE_PROTOCOL=https
+```
+
+`docusaurus.config.ts` reads `TYPESENSE_HOST`/`TYPESENSE_PORT`/`TYPESENSE_PROTOCOL`
+from the environment, defaulting to the production values
+(`docs.operaton.org`, `8108`, `https`) when unset.
+
+### 5. Populate the index and run the site
+
+Index some content into the `docusaurus` collection (for example with the
+same [`docsearch.config.json`](./docsearch.config.json) and the
+[`typesense-scraper`](https://github.com/celsiusnarhwal/typesense-scraper)
+tooling used in CI, pointed at your local dev server), then start Docusaurus
+as usual:
+
+```bash
+npm run start
+```
+
+Since the certificate is self-signed, browsers will show a security warning
+for `https://localhost:8108` the first time — open that URL directly once and
+accept the exception, or add the certificate to your system/browser trust
+store, before using the search box.
+
+### Background: issue #161
+
+Search on the production site failed because the Typesense server at
+`docs.operaton.org:8108` only accepted plain HTTP, while the browser (per
+`docusaurus.config.ts`) connects over HTTPS — the TLS handshake fails before
+any CORS headers can be returned, which browsers surface as a CORS error.
+This local setup demonstrates the fix: Typesense must terminate TLS on port
+8108 (via `--ssl-certificate`/`--ssl-certificate-key`, as configured in
+`docker/typesense/docker-compose.yml`), which is what needs to be replicated
+on the production server.

--- a/docker/typesense/docker-compose.yml
+++ b/docker/typesense/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  typesense:
+    image: typesense/typesense:27.1
+    container_name: operaton-docs-typesense
+    restart: unless-stopped
+    ports:
+      - "8108:8108"
+    volumes:
+      - ./data:/data
+      - ./certs:/certs:ro
+    environment:
+      TYPESENSE_API_KEY: ${TYPESENSE_API_KEY:?Set TYPESENSE_API_KEY in docker/typesense/.env}
+      TYPESENSE_DATA_DIR: /data
+      TYPESENSE_ENABLE_CORS: "true"
+      TYPESENSE_SSL_CERTIFICATE: /certs/cert.pem
+      TYPESENSE_SSL_CERTIFICATE_KEY: /certs/key.pem

--- a/docker/typesense/generate-certs.sh
+++ b/docker/typesense/generate-certs.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Generates a self-signed TLS certificate for the local Typesense dev server.
+# Typesense terminates TLS itself (--ssl-certificate / --ssl-certificate-key),
+# mirroring how the production server should be configured for port 8108.
+set -euo pipefail
+
+CERT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/certs"
+mkdir -p "$CERT_DIR"
+
+openssl req -x509 -newkey rsa:2048 -nodes \
+  -keyout "$CERT_DIR/key.pem" \
+  -out "$CERT_DIR/cert.pem" \
+  -days 825 \
+  -subj "/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+
+echo "Certificate written to $CERT_DIR/cert.pem"
+echo "Key written to $CERT_DIR/key.pem"
+echo
+echo "Trust this certificate in your browser/OS keychain, or curl with --insecure, to avoid TLS warnings."

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -8,6 +8,9 @@ import remarkBpmnDiagram from './src/plugins/remark-bpmn-diagram.js';
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
 const typesenseApiKey = process.env.TYPESENSE_API_KEY?.trim();
+const typesenseHost = process.env.TYPESENSE_HOST?.trim() || 'docs.operaton.org';
+const typesensePort = Number(process.env.TYPESENSE_PORT) || 8108;
+const typesenseProtocol = process.env.TYPESENSE_PROTOCOL?.trim() || 'https';
 
 const config: Config = {
   title: 'Operaton Documentation',
@@ -93,9 +96,9 @@ const config: Config = {
             typesenseServerConfig: {
               nodes: [
                 {
-                  host: 'docs.operaton.org',
-                  port: 8108,
-                  protocol: 'https',
+                  host: typesenseHost,
+                  port: typesensePort,
+                  protocol: typesenseProtocol,
                 },
               ],
               apiKey: typesenseApiKey,


### PR DESCRIPTION
## Summary
- Confirmed the root cause of #161 by testing directly against production: `curl https://docs.operaton.org:8108/health` fails the TLS handshake (`tlsv1 alert protocol version`), while `curl http://docs.operaton.org:8108/health` succeeds. The Typesense server only serves plain HTTP on port 8108, but `docusaurus.config.ts` (correctly) configures the browser to connect over HTTPS, so the TLS handshake fails before any CORS headers can be returned — which browsers surface as a CORS error.
- Added a `docker-compose` based local Typesense instance (`docker/typesense/`) that terminates TLS itself via `--ssl-certificate`/`--ssl-certificate-key`, mirroring the config the production server needs.
- Made the Typesense `host`/`port`/`protocol` configurable via `TYPESENSE_HOST`/`TYPESENSE_PORT`/`TYPESENSE_PROTOCOL` env vars (defaulting to the current production values), so the dev server can point at the local instance.
- Documented the setup and root cause in the README.

## Validation performed
- Started the local Typesense container with a self-signed cert; confirmed HTTPS works and plain HTTP is rejected (inverse of the current production behavior).
- Simulated the browser's CORS preflight (`OPTIONS`) and `multi_search` POST with an `Origin` header via curl — both succeeded with correct `access-control-allow-origin` headers.
- Ran the actual Docusaurus dev server against the local HTTPS Typesense instance and drove the real search UI with a headless browser: all `multi_search` requests returned `200` over HTTPS with no TLS/CORS errors, and results rendered correctly.

## Scope note
This PR fixes and validates everything that's within this repository's control (config consistency + a reproducible local reference setup). **The actual production fix — enabling TLS on the Typesense server at `docs.operaton.org:8108`, e.g. via the same `--ssl-certificate`/`--ssl-certificate-key` flags used here — is an infrastructure change on the server itself, outside this repo.** That still needs to be applied before search works again on the live site.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] Local Typesense + HTTPS + CORS validated via curl and headless browser

Closes (partially, pending production infra fix) #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rzoSBfH54ZSPFqtjQBhQa