### PR TITLE
fix: use http protocol for Typesense to match production server (#161)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,7 @@ jobs:
           port: 8108
 
           # The protocol to use when connecting to your Typesense server. Optional. Default: http.
-          protocol: https
+          protocol: http
 
           # The path to your DocSearch config file. Optional. Default: docsearch.config.json.
           config: docsearch.config.json

--- a/README.md
+++ b/README.md
@@ -40,43 +40,34 @@ Run the typecheck and production build before opening a pull request.
 ## Local Search (Typesense) Setup
 
 The production site queries a Typesense server directly from the browser
-(`typesenseServerConfig` in `docusaurus.config.ts`), over **HTTPS** on port
-`8108`. To develop or test the search integration locally — including
-reproducing HTTPS/CORS issues like
-[#161](https://github.com/operaton/documentation/issues/161) — run a local
-Typesense instance with TLS enabled via Docker Compose.
+(`typesenseServerConfig` in `docusaurus.config.ts`), over plain **HTTP** on
+port `8108`. The search API key embedded in the built site is a public,
+search-only key (it's shipped in client-side JS, same as any DocSearch-style
+integration), so there's no secret to protect and no TLS requirement.
+To develop or test the search integration locally, run a local Typesense
+instance via Docker Compose.
 
-### 1. Generate a local TLS certificate
-
-```bash
-./docker/typesense/generate-certs.sh
-```
-
-This creates a self-signed certificate/key in `docker/typesense/certs/`
-(git-ignored). Typesense terminates TLS itself using this certificate,
-the same way the production server must be configured.
-
-### 2. Configure an API key
+### 1. Configure an API key
 
 ```bash
 echo "TYPESENSE_API_KEY=some-local-dev-key" > docker/typesense/.env
 ```
 
-### 3. Start Typesense
+### 2. Start Typesense
 
 ```bash
 cd docker/typesense
 docker compose up -d
 ```
 
-Verify it's serving HTTPS correctly:
+Verify it's up:
 
 ```bash
-curl -sk https://localhost:8108/health
+curl -s http://localhost:8108/health
 # {"ok":true}
 ```
 
-### 4. Point Docusaurus at the local server
+### 3. Point Docusaurus at the local server
 
 Create a `.env` file in the repository root (git-ignored):
 
@@ -84,14 +75,14 @@ Create a `.env` file in the repository root (git-ignored):
 TYPESENSE_API_KEY=some-local-dev-key
 TYPESENSE_HOST=localhost
 TYPESENSE_PORT=8108
-TYPESENSE_PROTOCOL=https
+TYPESENSE_PROTOCOL=http
 ```
 
 `docusaurus.config.ts` reads `TYPESENSE_HOST`/`TYPESENSE_PORT`/`TYPESENSE_PROTOCOL`
 from the environment, defaulting to the production values
-(`docs.operaton.org`, `8108`, `https`) when unset.
+(`docs.operaton.org`, `8108`, `http`) when unset.
 
-### 5. Populate the index and run the site
+### 4. Populate the index and run the site
 
 Index some content into the `docusaurus` collection (for example with the
 same [`docsearch.config.json`](./docsearch.config.json) and the
@@ -103,18 +94,31 @@ as usual:
 npm run start
 ```
 
+### Optional: testing over HTTPS
+
+To test the search integration over HTTPS instead (e.g. if the production
+server's TLS setup ever changes), generate a self-signed certificate and
+layer on the TLS override:
+
+```bash
+./docker/typesense/generate-certs.sh
+docker compose -f docker-compose.yml -f docker-compose.tls.yml up -d
+```
+
 Since the certificate is self-signed, browsers will show a security warning
 for `https://localhost:8108` the first time — open that URL directly once and
 accept the exception, or add the certificate to your system/browser trust
-store, before using the search box.
+store.
 
 ### Background: issue #161
 
-Search on the production site failed because the Typesense server at
-`docs.operaton.org:8108` only accepted plain HTTP, while the browser (per
-`docusaurus.config.ts`) connects over HTTPS — the TLS handshake fails before
-any CORS headers can be returned, which browsers surface as a CORS error.
-This local setup demonstrates the fix: Typesense must terminate TLS on port
-8108 (via `--ssl-certificate`/`--ssl-certificate-key`, as configured in
-`docker/typesense/docker-compose.yml`), which is what needs to be replicated
-on the production server.
+Search on the production site failed because `docusaurus.config.ts` was
+configured to connect over HTTPS while the Typesense server at
+`docs.operaton.org:8108` only ever served plain HTTP — the TLS handshake
+fails before any CORS headers can be returned, which browsers surface as a
+CORS error. Confirmed via direct query against the production server (over
+HTTP, using the public search key from the deployed site) that the
+`docusaurus` collection is indexed correctly (15k+ documents, real search
+results) — only the protocol mismatch was broken. The fix is to keep
+`docusaurus.config.ts` and the scraper step in
+`.github/workflows/deploy.yml` on `protocol: http`, matching the server.

--- a/docker/typesense/docker-compose.tls.yml
+++ b/docker/typesense/docker-compose.tls.yml
@@ -1,0 +1,11 @@
+# Optional override to test the search integration over HTTPS locally.
+# Not required to match production, which serves Typesense over plain HTTP.
+# Usage: docker compose -f docker-compose.yml -f docker-compose.tls.yml up -d
+# Requires ./generate-certs.sh to have been run first.
+services:
+  typesense:
+    volumes:
+      - ./certs:/certs:ro
+    environment:
+      TYPESENSE_SSL_CERTIFICATE: /certs/cert.pem
+      TYPESENSE_SSL_CERTIFICATE_KEY: /certs/key.pem

--- a/docker/typesense/docker-compose.yml
+++ b/docker/typesense/docker-compose.yml
@@ -7,10 +7,7 @@ services:
       - "8108:8108"
     volumes:
       - ./data:/data
-      - ./certs:/certs:ro
     environment:
       TYPESENSE_API_KEY: ${TYPESENSE_API_KEY:?Set TYPESENSE_API_KEY in docker/typesense/.env}
       TYPESENSE_DATA_DIR: /data
       TYPESENSE_ENABLE_CORS: "true"
-      TYPESENSE_SSL_CERTIFICATE: /certs/cert.pem
-      TYPESENSE_SSL_CERTIFICATE_KEY: /certs/key.pem

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -10,7 +10,7 @@ import remarkBpmnDiagram from './src/plugins/remark-bpmn-diagram.js';
 const typesenseApiKey = process.env.TYPESENSE_API_KEY?.trim();
 const typesenseHost = process.env.TYPESENSE_HOST?.trim() || 'docs.operaton.org';
 const typesensePort = Number(process.env.TYPESENSE_PORT) || 8108;
-const typesenseProtocol = process.env.TYPESENSE_PROTOCOL?.trim() || 'https';
+const typesenseProtocol = process.env.TYPESENSE_PROTOCOL?.trim() || 'http';
 
 const config: Config = {
   title: 'Operaton Documentation',


### PR DESCRIPTION
## Summary
Follow-up to #166. Queried the production Typesense server directly over HTTP using the public search-only API key already embedded in the deployed site's JS bundle:

```
$ curl "http://docs.operaton.org:8108/collections/docusaurus" -H "X-TYPESENSE-API-KEY: ..."
{"...","num_documents":15692,...}

$ curl -X POST "http://docs.operaton.org:8108/multi_search?x-typesense-api-key=..." \
  -d '{"searches":[{"collection":"docusaurus","q":"process","query_by":"content,..."}]}'
{"results":[{"found":4469,"hits":[...real documentation content...]}]}
```

This proves the index is populated correctly and fully queryable — the server was never broken. It only ever served plain HTTP; `docusaurus.config.ts` and the scraper step in `deploy.yml` requesting HTTPS caused the TLS handshake to fail before any CORS headers could return, which browsers report as a CORS error.

- Revert `docusaurus.config.ts` default protocol and `.github/workflows/deploy.yml` scraper `protocol` back to `http`, matching the real server.
- The search API key is a public, search-only key shipped in client-side JS regardless of protocol — there's no secret to protect, so HTTP is an acceptable, intentional choice here.
- Local `docker/typesense/docker-compose.yml` now defaults to plain HTTP to match production; HTTPS is still available as an opt-in override (`docker-compose.tls.yml`) if the server's TLS posture ever changes.
- Updated README accordingly.

## Validation performed
- `npm run typecheck` / `npm run build` pass
- Local Typesense (plain HTTP) + real Docusaurus dev server + headless-browser search interaction: all `multi_search` requests returned `200` over HTTP with correct CORS headers, no failures
- Confirmed against production directly that the index already has 15k+ indexed documents

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rzoSBfH54ZSPFqtjQBhQa