### PR TITLE
docs(release-notes): 2.1.3 security note (netty/jackson pins, #3401)

### DIFF
--- a/docs/documentation/reference/release-notes/2_1/index.md
+++ b/docs/documentation/reference/release-notes/2_1/index.md
@@ -430,6 +430,12 @@ No configuration or code changes are required on the client side.
 
 ## Patch Releases
 
+### 2.1.3
+
+#### Security Vulnerabilities
+
+- **[fix(deps): pin vulnerable transitive dependencies](https://github.com/operaton/operaton/pull/3401)** — Pinned `netty` to `4.2.16.Final` (fixes [CVE-2026-56745](https://nvd.nist.gov/vuln/detail/CVE-2026-56745) and related netty advisories) and `jackson-bom` to `3.1.5` (fixes [CVE-2026-59889](https://nvd.nist.gov/vuln/detail/CVE-2026-59889)), overriding the vulnerable transitive versions managed by Spring Boot 4 and the Quarkus extension until those frameworks ship fixed versions. Backport of [#3390](https://github.com/operaton/operaton/pull/3390). (#3401)
+
 ### 2.1.2
 
 #### Bug Fixes


### PR DESCRIPTION
Adds a **2.1.3** entry under *Patch Releases* in the 2.1 release notes, documenting the security dependency pins backported to `release/2.1.x`.

## Content
- **Security Vulnerabilities** section for 2.1.3:
  - `netty` → 4.2.16.Final (CVE-2026-56745 + related netty advisories)
  - `jackson-bom` → 3.1.5 (CVE-2026-59889)
  - Source: operaton/operaton#3401 (backport of #3390)

## Notes for reviewer
- Draft — please sanity-check the CVE IDs/links and wording against the advisories before publishing.
- Prepared as part of the 2.1.3 release pre-flight (PREPARE). Should merge before 2.1.3 is cut.
